### PR TITLE
Adding configuration field for kubo-release location

### DIFF
--- a/bin/deploy_k8s
+++ b/bin/deploy_k8s
@@ -28,8 +28,6 @@ print_usage() {
   echo "     dev    - Build a dev release from the local machine."
   echo "              Required binaries and repos should be in ../"
   echo "     public - Use published releases from the internet"
-  echo "     local  - Use local releases"
-  echo "              Required binaries should be in ../"
   echo ""
 }
 
@@ -49,7 +47,7 @@ main() {
   fi
 
   case ${release_source} in
-    "dev"|"public"|"local") ;;
+    "dev"|"public") ;;
     "") release_source="public";;
     *) print_usage; exit 1;;
   esac
@@ -82,23 +80,17 @@ upload_releases() {
 
   case ${release_source} in
     "dev")
-      pushd ../ > /dev/null
-        create_and_upload_release 'kubo-release'
-        upload_release $(get_setting director.yml "/etcd_release_url")
-      popd > /dev/null
+      create_and_upload_release $(get_setting director.yml "/kubo_release_url")
+      upload_release $(get_setting director.yml "/etcd_release_url")
       ;;
     "public")
        upload_release $(get_setting director.yml "/etcd_release_url")
        echo "NYI: Kubo release not yet available on a public endpoint"
+       #upload_release $(get_setting director.yml "/kubo_release_url")
        exit 1
       ;;
-    "local")
-      pushd ../ > /dev/null
-        upload_release "kubo-release.tgz"
-        upload_release $(get_setting director.yml "/etcd_release_url")
-      popd > /dev/null
-      ;;
     *)
+
       echo "unknown RELEASE_SOURCE: '${release_source}'"
       exit 1
     esac

--- a/bin/lib/deploy_utils
+++ b/bin/lib/deploy_utils
@@ -34,16 +34,17 @@ deploy_to_bosh() {
 }
 
 create_and_upload_release() {
-  local release_dirname=$1
+  local repo_directory=$1
+  local release_dirname=$(basename $repo_directory)
   local release_name="${release_dirname%-release}"
 
-  if [ -d "$release_dirname" ]; then
-    pushd "$release_dirname"
+  if [ -d "$repo_directory" ]; then
+    pushd "$repo_directory"
       BOSH_CLIENT=bosh_admin BOSH_CLIENT_SECRET=$(get_bosh_secret) bosh-cli -e "${BOSH_NAME}" create-release --force --name "${release_name}"
       upload_release "--name=${release_name}" 
     popd
   else
-    echo "${release_dirname} repo not found - unable to create the ${release_name} release"
+    echo "${repo_directory} repo not found - unable to create the ${repo_directory} release"
     exit 1
   fi
 }

--- a/configurations/generic/project-config.yml
+++ b/configurations/generic/project-config.yml
@@ -18,6 +18,7 @@ bosh_release_sha1: # SHA1 of latest stable 261 bosh-director release
 credhub_encryption_key: # 16 byte number in HEX format: i.e. ABCDEF0123456789ABCDEF0123456789
 credhub_release_url: # URL to CredHub release 0.4 https://s3.amazonaws.com/kubo-public/credhub-0.4.0.tgz, or link to local file
 etcd_release_url: # URL to kubo etcd release https://s3.amazonaws.com/kubo-public/etcd-85%2Bdev.1.tgz, or link to local file
+kubo_release_url: # link to local repository, URL to built kubo release https://s3.amazonaws.com/kubo-public/kubo-release.LATEST.tgz, or link to local file
 director_name: # user friendly Director name
 dns_recursor_ip: # DNS IP address. Usually the same as gateway, see below
 internal_cidr: # CIDR range that BOSH will deploy to


### PR DESCRIPTION
[#139825081]

This is an idea for configuring the location of kubo-release. The field would either be a file location of an already built release, a url to an already built release, or the path to the repo. The reason I wanted to do this is because all of the other release locations are in the configuration file, and this is the only reason we need the "local" release option on the deploy_k8s script. I think this makes it less complicated. 