### PR TITLE
Add alias-env call after bosh deploy finishes

### DIFF
--- a/bin/deploy_bosh
+++ b/bin/deploy_bosh
@@ -24,7 +24,6 @@ if [ ! -d "${BOSH_ENV}" ]; then
 fi
 
 main() {
-  . ./bin/lib/deploy_utils
   iaas=$(cat "$BOSH_ENV"/iaas)
   if [ "$iaas" != 'gcp' ] && [ "$iaas" != 'openstack' ]; then
     echo "Supported platforms are: 'gcp', 'openstack'"
@@ -32,10 +31,11 @@ main() {
     print_usage
     exit 1
   fi
-
-  "deploy_$iaas"
-  generate_default_ca ${BOSH_ENV}
-  setup_bosh_alias
+  pushd $(dirname $0)/.. > /dev/null
+    "deploy_$iaas"
+    generate_default_ca ${BOSH_ENV}
+    setup_bosh_alias
+  popd
 }
 
 generate_default_ca() {
@@ -80,6 +80,21 @@ deploy_openstack() {
       --vars-file "${BOSH_ENV}/director.yml"  \
       --vars-file "${BOSH_ENV}/director-secrets.yml"  \
       --var-file private_key="${pk_filename}"
+}
+
+setup_bosh_alias() {
+  . ./bin/lib/deploy_utils
+
+  local bosh_director_hostname=$(get_setting "director.yml" /internal_ip)
+  local bosh_director_name=$(get_setting "director.yml" /director_name)
+
+  if [ -z ${bosh_director_hostname} ]; then
+    echo "Expected bosh director IP address specified as 'internal_ip' in director.yml"
+    exit 1
+  fi
+
+  ca_cert=$(bosh-cli int ${BOSH_ENV}/creds.yml --path=/default_ca/ca)
+  BOSH_CLIENT=bosh_admin BOSH_CLIENT_SECRET=$(get_bosh_secret) BOSH_CA_CERT=${ca_cert} bosh-cli alias-env "${bosh_director_name}" -e $bosh_director_hostname
 }
 
 main

--- a/bin/lib/deploy_utils
+++ b/bin/lib/deploy_utils
@@ -97,15 +97,3 @@ generate_manifest() {
   popd > /dev/null
 }
 
-setup_bosh_alias() {
-  local bosh_director_hostname=$(get_setting "director.yml" /internal_ip)
-  local bosh_director_name=$(get_setting "director.yml" /director_name)
-
-  if [ -z ${bosh_director_hostname} ]; then
-    echo "Expected bosh director IP address specified as 'internal_ip' in director.yml"
-    exit 1
-  fi
-
-  ca_cert=$(bosh-cli int ${BOSH_ENV}/creds.yml --path=/default_ca/ca)
-  BOSH_CLIENT=bosh_admin BOSH_CLIENT_SECRET=$(get_bosh_secret) BOSH_CA_CERT=${ca_cert} bosh-cli alias-env "${bosh_director_name}" -e $bosh_director_hostname
-}


### PR DESCRIPTION
[#139825037]

Neither deploy_bosh or deploy_k8s runs bosh-cli alias-env currently. Adding it to the end of deploy_bosh means that the cli will work properly right after deploy_bosh finishes.