### PR TITLE
Let the BOSH download etcd

### DIFF
--- a/bin/deploy_k8s
+++ b/bin/deploy_k8s
@@ -85,18 +85,15 @@ upload_releases() {
     "dev")
       pushd ../ > /dev/null
         create_and_upload_release 'kubo-release'
-        upload_release $(get_setting director.yml "/etcd_release_url")
       popd > /dev/null
       ;;
     "public")
-       upload_release $(get_setting director.yml "/etcd_release_url")
        echo "NYI: Kubo release not yet available on a public endpoint"
        exit 1
       ;;
     "local")
       pushd ../ > /dev/null
         upload_release "kubo-release.tgz"
-        upload_release $(get_setting director.yml "/etcd_release_url")
       popd > /dev/null
       ;;
     *)

--- a/configurations/generic/project-config.yml
+++ b/configurations/generic/project-config.yml
@@ -17,7 +17,6 @@ bosh_release_url: # URL to latest stable 261 bosh-director release https://s3.am
 bosh_release_sha1: # SHA1 of latest stable 261 bosh-director release
 credhub_encryption_key: # 16 byte number in HEX format: i.e. ABCDEF0123456789ABCDEF0123456789
 credhub_release_url: # URL to CredHub release 0.4 https://s3.amazonaws.com/kubo-public/credhub-0.4.0.tgz, or link to local file
-etcd_release_url: # URL to kubo etcd release https://s3.amazonaws.com/kubo-public/etcd-85%2Bdev.1.tgz, or link to local file
 director_name: # user friendly Director name
 dns_recursor_ip: # DNS IP address. Usually the same as gateway, see below
 internal_cidr: # CIDR range that BOSH will deploy to

--- a/manifests/service.yml
+++ b/manifests/service.yml
@@ -2,7 +2,9 @@ name: ((deployment_name))
 
 releases:
 - name: etcd
-  version: latest
+  version: 85+dev.1
+  url: https://s3.amazonaws.com/kubo-public/etcd-85%2Bdev.1.tgz
+  sha1: 3e2aa617afee3ce522effead79c6ab3cf73ec38b
 - name: kubo
   version: latest
 - name: docker


### PR DESCRIPTION
* we put etcd in public bucket. BOSH director can download manifest on
its own. Users can get public url from manifest. For full offline
support we need to upload docker release as well.

[#138049767]