### PR TITLE
Openstack configuration for dynamic networking, multi AZ and local artifacts

### DIFF
--- a/bin/deploy_bosh
+++ b/bin/deploy_bosh
@@ -97,6 +97,7 @@ deploy_openstack() {
     --ops-file "$(repo_directory)/configurations/generic/credhub.yml" \
     --ops-file "$(repo_directory)/configurations/openstack/multi-tenant.yml" \
     --ops-file "$(repo_directory)/configurations/openstack/bosh-dynamic.yml" \
+    --ops-file "$(repo_directory)/configurations/openstack/bosh-multiaz.yml" \
     --ops-file "$(repo_directory)/configurations/generic/bosh-admin-client.yml" \
     --state "${bosh_env}/state.json" \
     --vars-store "${bosh_env}/creds.yml" \

--- a/bin/deploy_bosh
+++ b/bin/deploy_bosh
@@ -96,6 +96,7 @@ deploy_openstack() {
     --ops-file "$(repo_directory)/bosh-deployment/powerdns.yml" \
     --ops-file "$(repo_directory)/configurations/generic/credhub.yml" \
     --ops-file "$(repo_directory)/configurations/openstack/multi-tenant.yml" \
+    --ops-file "$(repo_directory)/configurations/openstack/bosh-dynamic.yml" \
     --ops-file "$(repo_directory)/configurations/generic/bosh-admin-client.yml" \
     --state "${bosh_env}/state.json" \
     --vars-store "${bosh_env}/creds.yml" \

--- a/bin/deploy_bosh
+++ b/bin/deploy_bosh
@@ -98,6 +98,7 @@ deploy_openstack() {
     --ops-file "$(repo_directory)/configurations/openstack/multi-tenant.yml" \
     --ops-file "$(repo_directory)/configurations/openstack/bosh-dynamic.yml" \
     --ops-file "$(repo_directory)/configurations/openstack/bosh-multiaz.yml" \
+    --ops-file "$(repo_directory)/configurations/openstack/local-artifacts.yml" \
     --ops-file "$(repo_directory)/configurations/generic/bosh-admin-client.yml" \
     --state "${bosh_env}/state.json" \
     --vars-store "${bosh_env}/creds.yml" \

--- a/bin/deploy_bosh
+++ b/bin/deploy_bosh
@@ -98,6 +98,7 @@ deploy_openstack() {
     --ops-file "$(repo_directory)/configurations/openstack/multi-tenant.yml" \
     --ops-file "$(repo_directory)/configurations/openstack/bosh-dynamic.yml" \
     --ops-file "$(repo_directory)/configurations/openstack/bosh-multiaz.yml" \
+    --ops-file "$(repo_directory)/configurations/openstack/cpi_novanet.yml" \
     --ops-file "$(repo_directory)/configurations/openstack/local-artifacts.yml" \
     --ops-file "$(repo_directory)/configurations/generic/bosh-admin-client.yml" \
     --state "${bosh_env}/state.json" \

--- a/bin/generate_cloud_config
+++ b/bin/generate_cloud_config
@@ -25,10 +25,18 @@ main() {
   local bosh_iaas="$(bosh-cli int ${bosh_env}/director.yml --path '/iaas')"
   local cloud_config
   if [ "$(bosh-cli int "${bosh_env}/director.yml" --path='/routing_mode')" == "cf" ]; then
-    cloud_config=$(bosh-cli int "$(repo_directory)/configurations/${bosh_iaas}/cloud-config.yml" --vars-file ${bosh_env}/director.yml)
+    cloud_config=$(bosh-cli int "$(repo_directory)/configurations/${bosh_iaas}/cloud-config.yml")
   else
-    cloud_config=$(bosh-cli int "$(repo_directory)/configurations/${bosh_iaas}/cloud-config.yml" --vars-file ${bosh_env}/director.yml --ops-file="$(repo_directory)/manifests/ops-files/load_balancer_target_pools.yml")
+    cloud_config=$(bosh-cli int "$(repo_directory)/configurations/${bosh_iaas}/cloud-config.yml" --ops-file="$(repo_directory)/manifests/ops-files/load_balancer_target_pools.yml")
   fi
+
+  local dynamic_ops_file="$(repo_directory)/configurations/${bosh_iaas}/cloud-config-dynamic.yml"
+  if [ -f ${dynamic_ops_file} ]; then
+    cloud_config=$(echo "$cloud_config" | bosh-cli int - --ops-file ${dynamic_ops_file})
+  fi
+
+  cloud_config=$(echo "$cloud_config" | bosh-cli int - --vars-file ${bosh_env}/director.yml)
+
   echo -n "${cloud_config}"
 }
 

--- a/bin/generate_cloud_config
+++ b/bin/generate_cloud_config
@@ -35,6 +35,11 @@ main() {
     cloud_config=$(echo "$cloud_config" | bosh-cli int - --ops-file ${dynamic_ops_file})
   fi
 
+  local multiazs_ops_file="$(repo_directory)/configurations/${bosh_iaas}/cloud-config-multiaz.yml"
+  if [ -f ${multiazs_ops_file} ]; then
+    cloud_config=$(echo "$cloud_config" | bosh-cli int - --ops-file ${multiazs_ops_file})
+  fi
+
   cloud_config=$(echo "$cloud_config" | bosh-cli int - --vars-file ${bosh_env}/director.yml)
 
   echo -n "${cloud_config}"

--- a/configurations/openstack/bosh-dynamic.yml
+++ b/configurations/openstack/bosh-dynamic.yml
@@ -1,0 +1,27 @@
+---
+- type: replace
+  path: /networks/name=default/type?
+  value: dynamic
+
+- type: remove
+  path: /networks/name=default/subnets
+
+- type: replace
+  path: /networks/-
+  value:
+    name: public
+    type: vip
+
+- type: remove
+  path: /instance_groups/name=bosh/networks/name=default/static_ips
+
+- type: replace
+  path: /instance_groups/name=bosh/networks/name=default/default?
+  value: [dns, gateway]
+
+- type: replace
+  path: /instance_groups/name=bosh/networks/-
+  value:
+    name: public
+    static_ips: [((internal_ip))]
+

--- a/configurations/openstack/bosh-multiaz.yml
+++ b/configurations/openstack/bosh-multiaz.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /resource_pools/name=vms/cloud_properties/availability_zone?
+  value: ((az1))

--- a/configurations/openstack/cloud-config-dynamic.yml
+++ b/configurations/openstack/cloud-config-dynamic.yml
@@ -1,0 +1,11 @@
+---
+- type: replace
+  path: /networks/name=((deployments_network))?
+  value:
+    name: ((deployments_network))
+    type: dynamic
+    default: [dns, gateway]
+    subnets:
+    - azs: [z1]
+      cloud_properties:
+        security_groups: ((default_security_groups))

--- a/configurations/openstack/cloud-config-multiaz.yml
+++ b/configurations/openstack/cloud-config-multiaz.yml
@@ -1,0 +1,37 @@
+---
+- type: remove
+  path: /azs/name=z1
+- type: replace
+  path: /azs/-
+  value:
+    name: z1
+    cloud_properties:
+      availability_zone: ((az1))
+- type: replace
+  path: /azs/-
+  value:
+    name: z2
+    cloud_properties:
+      availability_zone: ((az2))
+- type: replace
+  path: /azs/-
+  value:
+    name: z3
+    cloud_properties:
+      availability_zone: ((az3))
+- type: replace
+  path: /azs/-
+  value:
+    name: z4
+    cloud_properties:
+      availability_zone: ((az4))
+- type: replace
+  path: /azs/-
+  value:
+    name: z5
+    cloud_properties:
+      availability_zone: ((az5))
+
+- type: replace
+  path: /networks/name=((deployments_network))/subnets/0/azs?
+  value: [z1,z2,z3,z4,z5]

--- a/configurations/openstack/cpi_novanet.yml
+++ b/configurations/openstack/cpi_novanet.yml
@@ -1,0 +1,7 @@
+---
+- type: replace
+  path: /cloud_provider/properties/openstack/use_nova_networking?
+  value: true
+- type: replace
+  path: /instance_groups/name=bosh/properties/openstack/use_nova_networking?
+  value: true

--- a/configurations/openstack/local-artifacts.yml
+++ b/configurations/openstack/local-artifacts.yml
@@ -1,0 +1,31 @@
+---
+- type: replace
+  path: /releases/name=bosh
+  value:
+    version: ((bosh_release_version))
+    url: ((bosh_release_url))
+    sha1: ((bosh_release_sha1))
+    name: bosh
+
+- type: replace
+  path: /releases/name=uaa
+  value:
+    version: ((uaa_release_version))
+    url: ((uaa_release_url))
+    sha1: ((uaa_release_sha1))
+    name: uaa
+
+- type: replace
+  path: /releases/name=bosh-openstack-cpi
+  value:
+    version: ((openstack_cpi_release_version))
+    url: ((openstack_cpi_release_url))
+    sha1: ((openstack_cpi_release_sha1))
+    name: bosh-openstack-cpi
+
+- type: replace
+  path: /resource_pools/name=vms/stemcell?
+  value:
+    version: ((stemcell_version))
+    url: ((stemcell_url))
+    sha1:  ((stemcell_sha1))

--- a/configurations/openstack/project-config.yml
+++ b/configurations/openstack/project-config.yml
@@ -12,3 +12,14 @@ openstack_project: # Openstack project ID
 openstack_tenant: # OpenStack tenant (required for multi-tenant environments)
 region: # OpenStack region (optional)
 openstack_username: # OpenStack admin username
+
+openstack_cpi_release_version: # Openstack CPI Release version
+openstack_cpi_release_url: # Openstack CPI Release path
+openstack_cpi_release_sha1: # Openstack CPI Release sha1
+stemcell_sha1: # Stemcell sha1
+uaa_release_version: # UAA Release version
+uaa_release_url: # UAA Release path
+uaa_release_sha1: # UAA Release sha1
+bosh_release_version: # Bosh Release version
+bosh_release_url: # Bosh Release path
+bosh_release_sha1: # Bosh Release sha1

--- a/configurations/openstack/project-config.yml
+++ b/configurations/openstack/project-config.yml
@@ -1,5 +1,9 @@
 auth_url: # OpenStack authentication URL
-az: # Availability zone
+az1: # Availability zone #1
+az2: # Availability zone #2
+az3: # Availability zone #3
+az4: # Availability zone #4
+az5: # Availability zone #5
 default_key_name: # Name of the SSH key pair
 default_security_groups: # List of security groups for the instances
 net_id: # OpenStack network identifier


### PR DESCRIPTION
Changes on configuration and scripts to enable deployment on an OpenStack environment that requires:
- dynamic networking: revised networking configuration on both bosh and loud config
- multi AZ: 5 AZs are configurable
- local artifacts: configurable paths (and versions and sha1) for all releases and stemcells for locked down environments with no connectivity to internet during deployment
- nova networking: included OPS file to add a flag for openstack environments still using Nova networking