### PR TITLE
Add kubernetes_master_port property to generic config

### DIFF
--- a/configurations/generic/project-config.yml
+++ b/configurations/generic/project-config.yml
@@ -21,6 +21,7 @@ kubo_release_url: https://storage.googleapis.com/kubo-public/kubo-release-latest
 # Comment this section when using CF routing mode
 routing_mode: iaas
 kubernetes_master_host: # IP address that can be used to reach the Kubernetes API, usually the address of a load balancer
+kubernetes_master_port: 8443 # Kubernetes API server port
 master_target_pool: # target pool that master nodes will be a part of
 worker_target_pool: # target pool that worker nodes will be a part of
 


### PR DESCRIPTION
`set_kubeconfig` require `kubernetes_master_port` property which is missing in generic configuration templates. https://github.com/cloudfoundry-incubator/kubo-deployment/blob/0c4f1b6d7f4f8f2bd7dfd42ca0b8a7cf4631b9c8/bin/set_kubeconfig#L59

https://github.com/cloudfoundry-incubator/kubo-deployment/commit/5538764c17de2985ca6a694d4a9e212852bac894 commit added this property only to test files.

```
++ bosh-cli int /kubo/director.yml --path /kubernetes_master_port
Expected to find a map key 'kubernetes_master_port' for path '/kubernetes_master_port' (found map keys: 'auth_url', 'az', 'credhub_encryption_key', 'credhub_release_url', 'default_key_name', 'default_security_groups', 'deployments_network', 'director_name', 'dns_recursor_ip', 'external-kubo-port', 'iaas', 'internal_cidr', 'internal_gw', 'internal_ip', 'kubernetes_master_host', 'kubo_release_url', 'master_target_pool', 'net_id', 'openstack_domain', 'openstack_project', 'openstack_username', 'routing_mode', 'stemcell_url', 'stemcell_version', 'worker_target_pool')
Exit code 1
```