### PR TITLE
Openstack configuration for dynamic networking, multi AZ and local artifacts with HAProxy

### DIFF
--- a/bin/deploy_bosh
+++ b/bin/deploy_bosh
@@ -96,6 +96,7 @@ deploy_openstack() {
     --ops-file "$(repo_directory)/bosh-deployment/powerdns.yml" \
     --ops-file "$(repo_directory)/bosh-deployment/credhub.yml" \
     --ops-file "$(repo_directory)/configurations/openstack/multi-tenant.yml" \
+    --ops-file "$(repo_directory)/configurations/openstack/bosh-dynamic.yml" \
     --ops-file "$(repo_directory)/configurations/generic/bosh-admin-client.yml" \
     --state "${bosh_env}/state.json" \
     --vars-store "${bosh_env}/creds.yml" \

--- a/bin/deploy_bosh
+++ b/bin/deploy_bosh
@@ -97,6 +97,7 @@ deploy_openstack() {
     --ops-file "$(repo_directory)/bosh-deployment/credhub.yml" \
     --ops-file "$(repo_directory)/configurations/openstack/multi-tenant.yml" \
     --ops-file "$(repo_directory)/configurations/openstack/bosh-dynamic.yml" \
+    --ops-file "$(repo_directory)/configurations/openstack/bosh-multiaz.yml" \
     --ops-file "$(repo_directory)/configurations/generic/bosh-admin-client.yml" \
     --state "${bosh_env}/state.json" \
     --vars-store "${bosh_env}/creds.yml" \

--- a/bin/deploy_bosh
+++ b/bin/deploy_bosh
@@ -98,6 +98,7 @@ deploy_openstack() {
     --ops-file "$(repo_directory)/configurations/openstack/multi-tenant.yml" \
     --ops-file "$(repo_directory)/configurations/openstack/bosh-dynamic.yml" \
     --ops-file "$(repo_directory)/configurations/openstack/bosh-multiaz.yml" \
+    --ops-file "$(repo_directory)/configurations/openstack/local-artifacts.yml" \
     --ops-file "$(repo_directory)/configurations/generic/bosh-admin-client.yml" \
     --state "${bosh_env}/state.json" \
     --vars-store "${bosh_env}/creds.yml" \

--- a/bin/deploy_bosh
+++ b/bin/deploy_bosh
@@ -98,6 +98,7 @@ deploy_openstack() {
     --ops-file "$(repo_directory)/configurations/openstack/multi-tenant.yml" \
     --ops-file "$(repo_directory)/configurations/openstack/bosh-dynamic.yml" \
     --ops-file "$(repo_directory)/configurations/openstack/bosh-multiaz.yml" \
+    --ops-file "$(repo_directory)/configurations/openstack/cpi_novanet.yml" \
     --ops-file "$(repo_directory)/configurations/openstack/local-artifacts.yml" \
     --ops-file "$(repo_directory)/configurations/generic/bosh-admin-client.yml" \
     --state "${bosh_env}/state.json" \

--- a/bin/destroy_bosh
+++ b/bin/destroy_bosh
@@ -111,7 +111,14 @@ destroy_openstack() {
   bosh-cli clean-up --all -n
   bosh-cli delete-env "$(repo_directory)/bosh-deployment/bosh.yml" \
     --ops-file "$(repo_directory)/bosh-deployment/openstack/cpi.yml" \
+    --ops-file "$(repo_directory)/bosh-deployment/uaa.yml" \
+    --ops-file "$(repo_directory)/bosh-deployment/powerdns.yml" \
+    --ops-file "$(repo_directory)/bosh-deployment/credhub.yml" \
     --ops-file "$(repo_directory)/configurations/openstack/multi-tenant.yml" \
+    --ops-file "$(repo_directory)/configurations/openstack/bosh-dynamic.yml" \
+    --ops-file "$(repo_directory)/configurations/openstack/bosh-multiaz.yml" \
+    --ops-file "$(repo_directory)/configurations/openstack/local-artifacts.yml" \
+    --ops-file "$(repo_directory)/configurations/generic/bosh-admin-client.yml" \
     --state "${bosh_env}/state.json" \
     --vars-store "${bosh_env}/creds.yml" \
     --vars-file "${bosh_env}/director.yml"  \

--- a/bin/destroy_bosh
+++ b/bin/destroy_bosh
@@ -117,6 +117,7 @@ destroy_openstack() {
     --ops-file "$(repo_directory)/configurations/openstack/multi-tenant.yml" \
     --ops-file "$(repo_directory)/configurations/openstack/bosh-dynamic.yml" \
     --ops-file "$(repo_directory)/configurations/openstack/bosh-multiaz.yml" \
+    --ops-file "$(repo_directory)/configurations/openstack/cpi_novanet.yml" \
     --ops-file "$(repo_directory)/configurations/openstack/local-artifacts.yml" \
     --ops-file "$(repo_directory)/configurations/generic/bosh-admin-client.yml" \
     --state "${bosh_env}/state.json" \

--- a/bin/generate_cloud_config
+++ b/bin/generate_cloud_config
@@ -24,13 +24,28 @@ main() {
   local bosh_env=$(cd "$1"; pwd)
   local bosh_iaas="$(bosh-cli int ${bosh_env}/director.yml --path '/iaas')"
   local cloud_config
+
   if [ "$(bosh-cli int "${bosh_env}/director.yml" --path='/routing_mode')" == "cf" ]; then
-     cloud_config=$(bosh-cli int "$(repo_directory)/configurations/${bosh_iaas}/cloud-config.yml" --vars-file ${bosh_env}/director.yml)
-  elif [ "$(bosh-cli int "${bosh_env}/director.yml" --path='/iaas')" == "gcp" ]; then
-     cloud_config=$(bosh-cli int "$(repo_directory)/configurations/${bosh_iaas}/cloud-config.yml" --vars-file ${bosh_env}/director.yml --ops-file="$(repo_directory)/manifests/ops-files/load_balancer_target_pools.yml")
+    cloud_config=$(bosh-cli int "$(repo_directory)/configurations/${bosh_iaas}/cloud-config.yml" --vars-file ${bosh_env}/director.yml
+
+  elif [ "$(bosh-cli int "${bosh_env}/director.yml" --path='/routing_mode')" == "iaas" ]; then
+
+    if [ "$(bosh-cli int "${bosh_env}/director.yml" --path='/iaas')" == "gcp" ]; then
+       cloud_config=$(bosh-cli int "$(repo_directory)/configurations/${bosh_iaas}/cloud-config.yml" --vars-file ${bosh_env}/director.yml --ops-file="$(repo_directory)/manifests/ops-files/load_balancer_target_pools.yml")
+    elif [ "$(bosh-cli int "${bosh_env}/director.yml" --path='/iaas')" == "aws" ]; then
+       cloud_config=$(bosh-cli int "$(repo_directory)/configurations/${bosh_iaas}/cloud-config.yml" --vars-file ${bosh_env}/director.yml --ops-file="$(repo_directory)/manifests/ops-files/aws_load_balancers.yml")
+    else
+       cloud_config=$(bosh-cli int "$(repo_directory)/configurations/${bosh_iaas}/cloud-config.yml" --vars-file ${bosh_env}/director.yml
+    fi
+
+  elif [ "$(bosh-cli int "${bosh_env}/director.yml" --path='/routing_mode')" == "proxy" ]; then
+    cloud_config=$(bosh-cli int "$(repo_directory)/configurations/${bosh_iaas}/cloud-config.yml" --vars-file ${bosh_env}/director.yml --ops-file="$(repo_directory)/manifests/ops-files/k8s_master_static_ip.yml")
+
   else
-     cloud_config=$(bosh-cli int "$(repo_directory)/configurations/${bosh_iaas}/cloud-config.yml" --vars-file ${bosh_env}/director.yml --ops-file="$(repo_directory)/manifests/ops-files/aws_load_balancers.yml")
+    cloud_config=$(bosh-cli int "$(repo_directory)/configurations/${bosh_iaas}/cloud-config.yml" --vars-file ${bosh_env}/director.yml)
+
   fi
+
   echo -n "${cloud_config}"
 }
 

--- a/bin/generate_cloud_config
+++ b/bin/generate_cloud_config
@@ -25,11 +25,11 @@ main() {
   local bosh_iaas="$(bosh-cli int ${bosh_env}/director.yml --path '/iaas')"
   local cloud_config
   if [ "$(bosh-cli int "${bosh_env}/director.yml" --path='/routing_mode')" == "cf" ]; then
-    cloud_config=$(bosh-cli int "$(repo_directory)/configurations/${bosh_iaas}/cloud-config.yml" --vars-file ${bosh_env}/director.yml)
+     cloud_config=$(bosh-cli int "$(repo_directory)/configurations/${bosh_iaas}/cloud-config.yml" --vars-file ${bosh_env}/director.yml)
   elif [ "$(bosh-cli int "${bosh_env}/director.yml" --path='/iaas')" == "gcp" ]; then
-    cloud_config=$(bosh-cli int "$(repo_directory)/configurations/${bosh_iaas}/cloud-config.yml" --vars-file ${bosh_env}/director.yml --ops-file="$(repo_directory)/manifests/ops-files/load_balancer_target_pools.yml")
+     cloud_config=$(bosh-cli int "$(repo_directory)/configurations/${bosh_iaas}/cloud-config.yml" --vars-file ${bosh_env}/director.yml --ops-file="$(repo_directory)/manifests/ops-files/load_balancer_target_pools.yml")
   else
-    cloud_config=$(bosh-cli int "$(repo_directory)/configurations/${bosh_iaas}/cloud-config.yml" --vars-file ${bosh_env}/director.yml --ops-file="$(repo_directory)/manifests/ops-files/aws_load_balancers.yml")
+     cloud_config=$(bosh-cli int "$(repo_directory)/configurations/${bosh_iaas}/cloud-config.yml" --vars-file ${bosh_env}/director.yml --ops-file="$(repo_directory)/manifests/ops-files/aws_load_balancers.yml")
   fi
   echo -n "${cloud_config}"
 }

--- a/bin/generate_cloud_config
+++ b/bin/generate_cloud_config
@@ -26,7 +26,7 @@ main() {
   local cloud_config
 
   if [ "$(bosh-cli int "${bosh_env}/director.yml" --path='/routing_mode')" == "cf" ]; then
-    cloud_config=$(bosh-cli int "$(repo_directory)/configurations/${bosh_iaas}/cloud-config.yml" --vars-file ${bosh_env}/director.yml
+    cloud_config=$(bosh-cli int "$(repo_directory)/configurations/${bosh_iaas}/cloud-config.yml" --vars-file ${bosh_env}/director.yml)
 
   elif [ "$(bosh-cli int "${bosh_env}/director.yml" --path='/routing_mode')" == "iaas" ]; then
 
@@ -35,7 +35,7 @@ main() {
     elif [ "$(bosh-cli int "${bosh_env}/director.yml" --path='/iaas')" == "aws" ]; then
        cloud_config=$(bosh-cli int "$(repo_directory)/configurations/${bosh_iaas}/cloud-config.yml" --vars-file ${bosh_env}/director.yml --ops-file="$(repo_directory)/manifests/ops-files/aws_load_balancers.yml")
     else
-       cloud_config=$(bosh-cli int "$(repo_directory)/configurations/${bosh_iaas}/cloud-config.yml" --vars-file ${bosh_env}/director.yml
+       cloud_config=$(bosh-cli int "$(repo_directory)/configurations/${bosh_iaas}/cloud-config.yml" --vars-file ${bosh_env}/director.yml)
     fi
 
   elif [ "$(bosh-cli int "${bosh_env}/director.yml" --path='/routing_mode')" == "proxy" ]; then

--- a/bin/generate_cloud_config
+++ b/bin/generate_cloud_config
@@ -23,10 +23,19 @@ main() {
 
   local bosh_env=$(cd "$1"; pwd)
   local bosh_iaas="$(bosh-cli int ${bosh_env}/director.yml --path '/iaas')"
+  local dynamic_ops_file="$(repo_directory)/configurations/${bosh_iaas}/cloud-config-dynamic.yml"
   local cloud_config
 
   if [ "$(bosh-cli int "${bosh_env}/director.yml" --path='/routing_mode')" == "cf" ]; then
-    cloud_config=$(bosh-cli int "$(repo_directory)/configurations/${bosh_iaas}/cloud-config.yml" --vars-file ${bosh_env}/director.yml)
+    if [ "$(bosh-cli int "${bosh_env}/director.yml" --path='/iaas')" == "openstack" ]; then
+       cloud_config=$(bosh-cli int "$(repo_directory)/configurations/${bosh_iaas}/cloud-config.yml")
+       if [ -f ${dynamic_ops_file} ]; then
+         cloud_config=$(echo "$cloud_config" | bosh-cli int - --ops-file ${dynamic_ops_file})
+       fi
+       cloud_config=$(echo "$cloud_config" | bosh-cli int - --vars-file ${bosh_env}/director.yml)
+    else   
+      cloud_config=$(bosh-cli int "$(repo_directory)/configurations/${bosh_iaas}/cloud-config.yml" --vars-file ${bosh_env}/director.yml)
+    fi
 
   elif [ "$(bosh-cli int "${bosh_env}/director.yml" --path='/routing_mode')" == "iaas" ]; then
 
@@ -39,7 +48,15 @@ main() {
     fi
 
   elif [ "$(bosh-cli int "${bosh_env}/director.yml" --path='/routing_mode')" == "proxy" ]; then
-    cloud_config=$(bosh-cli int "$(repo_directory)/configurations/${bosh_iaas}/cloud-config.yml" --vars-file ${bosh_env}/director.yml --ops-file="$(repo_directory)/manifests/ops-files/k8s_master_static_ip.yml")
+    if [ "$(bosh-cli int "${bosh_env}/director.yml" --path='/iaas')" == "openstack" ]; then
+      cloud_config=$(bosh-cli int "$(repo_directory)/configurations/${bosh_iaas}/cloud-config.yml")
+      if [ -f ${dynamic_ops_file} ]; then
+        cloud_config=$(echo "$cloud_config" | bosh-cli int - --ops-file ${dynamic_ops_file})
+      fi
+      cloud_config=$(echo "$cloud_config" | bosh-cli int - --vars-file ${bosh_env}/director.yml)
+    else
+      cloud_config=$(bosh-cli int "$(repo_directory)/configurations/${bosh_iaas}/cloud-config.yml" --vars-file ${bosh_env}/director.yml --ops-file="$(repo_directory)/manifests/ops-files/k8s_master_static_ip.yml")
+    fi
 
   else
     cloud_config=$(bosh-cli int "$(repo_directory)/configurations/${bosh_iaas}/cloud-config.yml" --vars-file ${bosh_env}/director.yml)

--- a/bin/generate_cloud_config
+++ b/bin/generate_cloud_config
@@ -24,6 +24,7 @@ main() {
   local bosh_env=$(cd "$1"; pwd)
   local bosh_iaas="$(bosh-cli int ${bosh_env}/director.yml --path '/iaas')"
   local dynamic_ops_file="$(repo_directory)/configurations/${bosh_iaas}/cloud-config-dynamic.yml"
+  local multiazs_ops_file="$(repo_directory)/configurations/${bosh_iaas}/cloud-config-multiaz.yml"
   local cloud_config
 
   if [ "$(bosh-cli int "${bosh_env}/director.yml" --path='/routing_mode')" == "cf" ]; then
@@ -31,6 +32,9 @@ main() {
        cloud_config=$(bosh-cli int "$(repo_directory)/configurations/${bosh_iaas}/cloud-config.yml")
        if [ -f ${dynamic_ops_file} ]; then
          cloud_config=$(echo "$cloud_config" | bosh-cli int - --ops-file ${dynamic_ops_file})
+       fi
+       if [ -f ${multiazs_ops_file} ]; then
+         cloud_config=$(echo "$cloud_config" | bosh-cli int - --ops-file ${multiazs_ops_file})
        fi
        cloud_config=$(echo "$cloud_config" | bosh-cli int - --vars-file ${bosh_env}/director.yml)
     else   
@@ -52,6 +56,9 @@ main() {
       cloud_config=$(bosh-cli int "$(repo_directory)/configurations/${bosh_iaas}/cloud-config.yml")
       if [ -f ${dynamic_ops_file} ]; then
         cloud_config=$(echo "$cloud_config" | bosh-cli int - --ops-file ${dynamic_ops_file})
+      fi
+      if [ -f ${multiazs_ops_file} ]; then
+        cloud_config=$(echo "$cloud_config" | bosh-cli int - --ops-file ${multiazs_ops_file})
       fi
       cloud_config=$(echo "$cloud_config" | bosh-cli int - --vars-file ${bosh_env}/director.yml)
     else

--- a/bin/lib/deploy_utils
+++ b/bin/lib/deploy_utils
@@ -87,11 +87,8 @@ generate_manifest() {
     manifest=$(echo "$manifest" | bosh-cli int - --ops-file="${manifest_dir}/ops-files/cf-routing.yml")
   fi
 
-  if bosh-cli int "${bosh_environment}/director.yml" --path='/worker_haproxy_tcp_frontend_port' &>/dev/null && bosh-cli int "${bosh_environment}/director.yml" --path='/worker_haproxy_tcp_backend_port' &>/dev/null; then
+  if [ "$(bosh-cli int "${bosh_environment}/director.yml" --path='/routing_mode')" == "proxy" ]; then
     manifest=$(echo "$manifest" | bosh-cli int - --ops-file="${manifest_dir}/ops-files/worker-haproxy.yml")
-  fi
-
-  if bosh-cli int "${bosh_environment}/director.yml" --path='/master_haproxy_tcp_frontend_port' &>/dev/null && bosh-cli int "${bosh_environment}/director.yml" --path='/master_haproxy_tcp_backend_port' &>/dev/null; then
     manifest=$(echo "$manifest" | bosh-cli int - --ops-file="${manifest_dir}/ops-files/master-haproxy.yml")
   fi
 

--- a/bin/lib/deploy_utils
+++ b/bin/lib/deploy_utils
@@ -87,8 +87,12 @@ generate_manifest() {
     manifest=$(echo "$manifest" | bosh-cli int - --ops-file="${manifest_dir}/ops-files/cf-routing.yml")
   fi
 
-  if bosh-cli int "${bosh_environment}/director.yml" --path='/haproxy_tcp_frontend_port' &>/dev/null && bosh-cli int "${bosh_environment}/director.yml" --path='/haproxy_tcp_backend_port' &>/dev/null; then
-    manifest=$(echo "$manifest" | bosh-cli int - --ops-file="${manifest_dir}/ops-files/haproxy.yml")
+  if bosh-cli int "${bosh_environment}/director.yml" --path='/worker_haproxy_tcp_frontend_port' &>/dev/null && bosh-cli int "${bosh_environment}/director.yml" --path='/worker_haproxy_tcp_backend_port' &>/dev/null; then
+    manifest=$(echo "$manifest" | bosh-cli int - --ops-file="${manifest_dir}/ops-files/worker-haproxy.yml")
+  fi
+
+  if bosh-cli int "${bosh_environment}/director.yml" --path='/master_haproxy_tcp_frontend_port' &>/dev/null && bosh-cli int "${bosh_environment}/director.yml" --path='/master_haproxy_tcp_backend_port' &>/dev/null; then
+    manifest=$(echo "$manifest" | bosh-cli int - --ops-file="${manifest_dir}/ops-files/master-haproxy.yml")
   fi
 
   if [ -e "${bosh_environment}/${deployment_name}-vars.yml" ]; then

--- a/bin/lib/deploy_utils
+++ b/bin/lib/deploy_utils
@@ -87,6 +87,10 @@ generate_manifest() {
     manifest=$(echo "$manifest" | bosh-cli int - --ops-file="${manifest_dir}/ops-files/cf-routing.yml")
   fi
 
+  if bosh-cli int "${bosh_environment}/director.yml" --path='/haproxy_tcp_frontend_port' &>/dev/null && bosh-cli int "${bosh_environment}/director.yml" --path='/haproxy_tcp_backend_port' &>/dev/null; then
+    manifest=$(echo "$manifest" | bosh-cli int - --ops-file="${manifest_dir}/ops-files/haproxy.yml")
+  fi
+
   if [ -e "${bosh_environment}/${deployment_name}-vars.yml" ]; then
     manifest=$(echo "${manifest}" | bosh-cli int - --vars-file="${bosh_environment}/${deployment_name}-vars.yml")
   fi

--- a/bin/lib/deploy_utils
+++ b/bin/lib/deploy_utils
@@ -83,14 +83,20 @@ generate_manifest() {
     manifest=$(echo "$manifest" | bosh-cli int - --ops-file="${manifest_dir}/ops-files/add-no-proxy.yml")
   fi
 
-  if [ "$(bosh-cli int "${bosh_environment}/director.yml" --path='/routing_mode')" == "cf" ]; then
-    manifest=$(echo "$manifest" | bosh-cli int - --ops-file="${manifest_dir}/ops-files/cf-routing.yml")
-  fi
 
-  if [ "$(bosh-cli int "${bosh_environment}/director.yml" --path='/routing_mode')" == "proxy" ]; then
-    manifest=$(echo "$manifest" | bosh-cli int - --ops-file="${manifest_dir}/ops-files/worker-haproxy.yml")
-    manifest=$(echo "$manifest" | bosh-cli int - --ops-file="${manifest_dir}/ops-files/master-haproxy.yml")
-  fi
+  case "$(bosh-cli int "${bosh_environment}/director.yml" --path='/routing_mode')" in
+    cf)
+        manifest=$(echo "$manifest" | bosh-cli int - --ops-file="${manifest_dir}/ops-files/cf-routing.yml")
+        manifest=$(echo "$manifest" | bosh-cli int - --ops-file="${manifest_dir}/ops-files/remove-haproxy.yml")
+    ;;
+    proxy)
+        manifest=$(echo "$manifest" | bosh-cli int - --ops-file="${manifest_dir}/ops-files/worker-haproxy.yml")
+        manifest=$(echo "$manifest" | bosh-cli int - --ops-file="${manifest_dir}/ops-files/master-haproxy.yml")
+    ;;
+    *)
+        manifest=$(echo "$manifest" | bosh-cli int - --ops-file="${manifest_dir}/ops-files/remove-haproxy.yml")
+    ;;
+  esac
 
   if [ -e "${bosh_environment}/${deployment_name}-vars.yml" ]; then
     manifest=$(echo "${manifest}" | bosh-cli int - --vars-file="${bosh_environment}/${deployment_name}-vars.yml")

--- a/bin/lib/deploy_utils
+++ b/bin/lib/deploy_utils
@@ -67,10 +67,6 @@ generate_manifest() {
   manifest_dir=$(cd "$(dirname "${manifest_path}")"; pwd)
   manifest="$(cat "${manifest_path}")"
 
-  if [ -e "${bosh_environment}/${deployment_name}.yml" ]; then
-    manifest=$(echo "${manifest}" | bosh-cli int - --ops-file="${bosh_environment}/${deployment_name}.yml")
-  fi
-
   if bosh-cli int "${bosh_environment}/director.yml" --path='/http_proxy' &>/dev/null; then
     manifest=$(echo "$manifest" | bosh-cli int - --ops-file="${manifest_dir}/ops-files/add-http-proxy.yml")
   fi
@@ -97,6 +93,10 @@ generate_manifest() {
         manifest=$(echo "$manifest" | bosh-cli int - --ops-file="${manifest_dir}/ops-files/remove-haproxy.yml")
     ;;
   esac
+
+  if [ -e "${bosh_environment}/${deployment_name}.yml" ]; then
+    manifest=$(echo "${manifest}" | bosh-cli int - --ops-file="${bosh_environment}/${deployment_name}.yml")
+  fi
 
   if [ -e "${bosh_environment}/${deployment_name}-vars.yml" ]; then
     manifest=$(echo "${manifest}" | bosh-cli int - --vars-file="${bosh_environment}/${deployment_name}-vars.yml")

--- a/configurations/generic/project-config.yml
+++ b/configurations/generic/project-config.yml
@@ -6,7 +6,7 @@ credhub_encryption_key: # 16 byte number in HEX format: i.e. ABCDEF0123456789ABC
 
 internal_cidr: # CIDR range that BOSH will deploy to
 internal_gw: # internal gateway
-external-kubo-port: # Port to use for Kubernetes API
+kubernetes_master_port: # Port to use for Kubernetes API
 
 director_name: # user friendly Director name
 dns_recursor_ip: # DNS IP address for resolving non-BOSH hostnames
@@ -27,7 +27,7 @@ worker_target_pool: # target pool that worker nodes will be a part of
 # CF routing mode settings
 # Uncomment and configure the lines below to leverage CF routing instead of IaaS routing
 # routing_mode: cf
-# cf-tcp-router-name: # Hostname of TCP router. Use `cf domains` to find existing TCP domain. If none exists, see https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#shared-domains for instructions to create one.
+# kubernetes_master_host: # Hostname of TCP router. Use `cf domains` to find existing TCP domain. If none exists, see https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#shared-domains for instructions to create one.
 # routing-cf-api-url: # TCP routing API URL. In PCF: https://api.<system domain>
 # routing-cf-client-id: # Routing UAA client name that will be used to register tcp routes
 # routing-cf-uaa-url: # Routing UAA URL In PCF: https://uaa.<system domain>

--- a/configurations/generic/project-config.yml
+++ b/configurations/generic/project-config.yml
@@ -17,6 +17,8 @@ stemcell_url: # path to a stemcell used in all Kubo deployments
 credhub_release_url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=1.0.0
 kubo_release_url: https://storage.googleapis.com/kubo-public/kubo-release-latest.tgz
 
+# routing_mode: haproxy
+
 # IaaS routing mode settings
 # Comment this section when using CF routing mode
 routing_mode: iaas

--- a/configurations/openstack/bosh-dynamic.yml
+++ b/configurations/openstack/bosh-dynamic.yml
@@ -1,0 +1,26 @@
+---
+- type: replace
+  path: /networks/name=default/type?
+  value: dynamic
+
+- type: remove
+  path: /networks/name=default/subnets
+
+- type: replace
+  path: /networks/-
+  value:
+    name: public
+    type: vip
+
+- type: remove
+  path: /instance_groups/name=bosh/networks/name=default/static_ips
+
+- type: replace
+  path: /instance_groups/name=bosh/networks/name=default/default?
+  value: [dns, gateway]
+
+- type: replace
+  path: /instance_groups/name=bosh/networks/-
+  value:
+    name: public
+    static_ips: [((internal_ip))]

--- a/configurations/openstack/bosh-multiaz.yml
+++ b/configurations/openstack/bosh-multiaz.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /resource_pools/name=vms/cloud_properties/availability_zone?
+  value: ((az1))

--- a/configurations/openstack/cloud-config-dynamic.yml
+++ b/configurations/openstack/cloud-config-dynamic.yml
@@ -1,0 +1,11 @@
+---
+- type: replace
+  path: /networks/name=((deployments_network))?
+  value:
+    name: ((deployments_network))
+    type: dynamic
+    default: [dns, gateway]
+    subnets:
+    - azs: [z1]
+      cloud_properties:
+        security_groups: ((default_security_groups))

--- a/configurations/openstack/cloud-config-dynamic.yml
+++ b/configurations/openstack/cloud-config-dynamic.yml
@@ -9,3 +9,9 @@
     - azs: [z1]
       cloud_properties:
         security_groups: ((default_security_groups))
+
+- type: replace
+  path: /networks/-
+  value:
+    name: public
+    type: vip

--- a/configurations/openstack/cloud-config-multiaz.yml
+++ b/configurations/openstack/cloud-config-multiaz.yml
@@ -1,0 +1,37 @@
+---
+- type: remove
+  path: /azs/name=z1
+- type: replace
+  path: /azs/-
+  value:
+    name: z1
+    cloud_properties:
+      availability_zone: ((az1))
+- type: replace
+  path: /azs/-
+  value:
+    name: z2
+    cloud_properties:
+      availability_zone: ((az2))
+- type: replace
+  path: /azs/-
+  value:
+    name: z3
+    cloud_properties:
+      availability_zone: ((az3))
+- type: replace
+  path: /azs/-
+  value:
+    name: z4
+    cloud_properties:
+      availability_zone: ((az4))
+- type: replace
+  path: /azs/-
+  value:
+    name: z5
+    cloud_properties:
+      availability_zone: ((az5))
+
+- type: replace
+  path: /networks/name=((deployments_network))/subnets/0/azs?
+  value: [z1,z2,z3,z4,z5]

--- a/configurations/openstack/cpi_novanet.yml
+++ b/configurations/openstack/cpi_novanet.yml
@@ -1,0 +1,7 @@
+---
+- type: replace
+  path: /cloud_provider/properties/openstack/use_nova_networking?
+  value: true
+- type: replace
+  path: /instance_groups/name=bosh/properties/openstack/use_nova_networking?
+  value: true

--- a/configurations/openstack/local-artifacts.yml
+++ b/configurations/openstack/local-artifacts.yml
@@ -1,0 +1,31 @@
+---
+- type: replace
+  path: /releases/name=bosh
+  value:
+    version: ((bosh_release_version))
+    url: ((bosh_release_url))
+    sha1: ((bosh_release_sha1))
+    name: bosh
+
+- type: replace
+  path: /releases/name=uaa
+  value:
+    version: ((uaa_release_version))
+    url: ((uaa_release_url))
+    sha1: ((uaa_release_sha1))
+    name: uaa
+
+- type: replace
+  path: /releases/name=bosh-openstack-cpi
+  value:
+    version: ((openstack_cpi_release_version))
+    url: ((openstack_cpi_release_url))
+    sha1: ((openstack_cpi_release_sha1))
+    name: bosh-openstack-cpi
+
+- type: replace
+  path: /resource_pools/name=vms/stemcell?
+  value:
+    version: ((stemcell_version))
+    url: ((stemcell_url))
+    sha1:  ((stemcell_sha1))

--- a/configurations/openstack/project-config.yml
+++ b/configurations/openstack/project-config.yml
@@ -12,3 +12,14 @@ openstack_project: # Openstack project ID
 openstack_tenant: # OpenStack tenant (required for multi-tenant environments)
 region: # OpenStack region (optional)
 openstack_username: # OpenStack admin username
+
+openstack_cpi_release_version: # Openstack CPI Release version
+openstack_cpi_release_url: # Openstack CPI Release path
+openstack_cpi_release_sha1: # Openstack CPI Release sha1
+stemcell_sha1: # Stemcell sha1
+uaa_release_version: # UAA Release version
+uaa_release_url: # UAA Release path
+uaa_release_sha1: # UAA Release sha1
+bosh_release_version: # Bosh Release version
+bosh_release_url: # Bosh Release path
+bosh_release_sha1: # Bosh Release sha1

--- a/configurations/openstack/project-config.yml
+++ b/configurations/openstack/project-config.yml
@@ -1,5 +1,9 @@
 auth_url: # OpenStack authentication URL
-az: # Availability zone
+az1: # Availability zone #1
+az2: # Availability zone #2
+az3: # Availability zone #3
+az4: # Availability zone #4
+az5: # Availability zone #5
 default_key_name: # Name of the SSH key pair
 default_security_groups: # List of security groups for the instances
 net_id: # OpenStack network identifier

--- a/configurations/vsphere/cloud-config.yml
+++ b/configurations/vsphere/cloud-config.yml
@@ -16,6 +16,7 @@ networks:
     cloud_properties:
       name: ((network_name))
     reserved: ((reserved_ips))
+    static: []
 
 vm_types:
 - name: common

--- a/docs/guides/gcp-cf/director.yml.erb
+++ b/docs/guides/gcp-cf/director.yml.erb
@@ -25,7 +25,7 @@ credhub_encryption_key: <%= SecureRandom.hex(16) %> # 16 byte number in HEX form
 
 internal_cidr: <%= ip_prefix %>.0/24 # CIDR range that BOSH will deploy to
 internal_gw: <%= ip_prefix %>.1 # internal gateway
-external-kubo-port: 1025 # Port to use for Kubernetes API
+kubernetes-master-port: 1025 # Port to use for Kubernetes API
 
 director_name: kube # user friendly Director name
 dns_recursor_ip: <%= ip_prefix %>.1 # DNS IP address for resolving non-BOSH hostnames
@@ -39,7 +39,7 @@ kubo_release_url: https://storage.googleapis.com/kubo-public/kubo-release-latest
 
 # CF routing mode settings
 routing_mode: cf
-cf-tcp-router-name: <%= ENV['tcp_router_domain'] %> # Hostname of TCP router. Use `cf domains` to find existing TCP domain. If none exists, see https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#shared-domains for instructions to create one.
+kubernetes-master-host: <%= ENV['tcp_router_domain'] %> # Hostname of TCP router. Use `cf domains` to find existing TCP domain. If none exists, see https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#shared-domains for instructions to create one.
 routing-cf-api-url: https://api.<%= ENV['cf_system_domain'] %> # TCP routing API URL. In PCF: https://api.<system domain>
 routing-cf-client-id: <%= ENV['routing_cf_client_id'] %> # Routing UAA client name that will be used to register tcp routes
 routing-cf-uaa-url: https://uaa.<%= ENV['cf_system_domain'] %> # Routing UAA URL In PCF: https://uaa.<system domain>

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -159,7 +159,7 @@ L Error: Action Failed get_task: Task 75bce522-4fba-4295-7b8c-d63d86f7dcc6 resul
 
 ### Solution
 
-Make sure that port specified as `external-kubo-port` is not already in use by another kubo cluster. The value in `director.yml` can be overridden using [var-files](./docs/guides/customized-installation.md#generate-manifest-and-deploy) for different clusters.   
+Make sure that port specified as `kubernetes-master-port` is not already in use by another kubo cluster. The value in `director.yml` can be overridden using [var-files](./docs/guides/customized-installation.md#generate-manifest-and-deploy) for different clusters.   
 
 ## Other connectivity issues
 

--- a/manifests/kubo.yml
+++ b/manifests/kubo.yml
@@ -74,6 +74,7 @@ instance_groups:
   instances: 1
   networks:
   - name: ((deployments_network))
+    static_ips: []
   azs: [z1]
   stemcell: trusty
   vm_type: common

--- a/manifests/kubo.yml
+++ b/manifests/kubo.yml
@@ -11,6 +11,10 @@ releases:
   version: 28.0.1
   url: https://bosh.io/d/github.com/cf-platform-eng/docker-boshrelease?v=28.0.1
   sha1: 448eaa2f478dc8794933781b478fae02aa44ed6b
+- name: haproxy
+  url: https://storage.googleapis.com/kubo-releases/haproxy_tmp_v8.2.x.tgz
+  sha1: 90c314cee3551d32860ed6faf405648abae888b8
+  version: latest
 
 stemcells:
 - alias: trusty
@@ -65,6 +69,24 @@ instance_groups:
       kubernetes-api-url: *kubo_url
   stemcell: trusty
   vm_type: master
+
+- name: master-haproxy
+  instances: 1
+  networks:
+  - name: ((deployments_network))
+  azs: [z1]
+  stemcell: trusty
+  vm_type: common
+  jobs:
+  - name: haproxy
+    release: haproxy
+
+    consumes:
+      tcp_backend: { from: master_haproxy }
+
+    properties:
+      ha_proxy:
+        tcp_link_port: 9999 # required, but not used
 
 - name: worker
   instances: 3

--- a/manifests/kubo.yml
+++ b/manifests/kubo.yml
@@ -55,7 +55,7 @@ instance_groups:
   - name: kubeconfig
     release: kubo
     properties:
-      kubernetes-api-url: &kubo_url "https://((kubernetes_master_host)):((kubernetes-master-port))"
+      kubernetes-api-url: &kubo_url "https://((kubernetes_master_host)):((kubernetes_master_port))"
       kubelet-password: ((kubelet-password))
       tls:
         kubernetes: ((tls-kubernetes))

--- a/manifests/kubo.yml
+++ b/manifests/kubo.yml
@@ -51,7 +51,7 @@ instance_groups:
   - name: kubeconfig
     release: kubo
     properties:
-      kubernetes-api-url: &kubo_url "https://((kubernetes_master_host)):8443"
+      kubernetes-api-url: &kubo_url "https://((kubernetes_master_host)):((kubernetes-master-port))"
       kubelet-password: ((kubelet-password))
       tls:
         kubernetes: ((tls-kubernetes))

--- a/manifests/ops-files/cf-routing.yml
+++ b/manifests/ops-files/cf-routing.yml
@@ -1,37 +1,18 @@
 - type: replace
-  path: /instance_groups/name=master/jobs/name=kubeconfig/properties/kubernetes-api-url
-  value: "https://((cf-tcp-router-name)):((external-kubo-port))"
-- type: replace
-  path: /instance_groups/name=master/jobs/name=kubernetes-system-specs/properties/kubernetes-api-url
-  value: "https://((cf-tcp-router-name)):((external-kubo-port))"
-
-- type: replace
-  path: /instance_groups/name=worker/jobs/name=kubeconfig/properties/kubernetes-api-url
-  value: "https://((cf-tcp-router-name)):((external-kubo-port))"
-
-- type: replace
-  path: /instance_groups/name=worker/jobs/name=kubelet/properties/kubernetes-api-url
-  value: "https://((cf-tcp-router-name)):((external-kubo-port))"
-
-- type: replace
-  path: /instance_groups/name=worker/jobs/name=kubernetes-proxy/properties/kubernetes-api-url
-  value: "https://((cf-tcp-router-name)):((external-kubo-port))"
-
-- type: replace
   path: /variables/name=tls-kubelet/options/common_name
-  value: ((cf-tcp-router-name))
+  value: ((kubernetes-master-host))
 
 - type: replace
   path: /variables/name=tls-kubelet/options/alternative_names
-  value: [((cf-tcp-router-name))]
+  value: [((kubernetes-master-host))]
 
 - type: replace
   path: /variables/name=tls-kubernetes/options/common_name
-  value: ((cf-tcp-router-name))
+  value: ((kubernetes-master-host))
 
 - type: replace
   path: /variables/name=tls-kubernetes/options/alternative_names
-  value: [((cf-tcp-router-name))]
+  value: [((kubernetes-master-host))]
 
 - type: replace
   path: /instance_groups/name=master/jobs/-
@@ -39,7 +20,7 @@
     name: kubernetes-api-route-registrar
     release: kubo
     properties:
-      external_kubo_port: ((external-kubo-port))
+      external_kubo_port: ((kubernetes-master-port))
       cloud_foundry:
         api_url: ((routing-cf-api-url))
         uaa_url: ((routing-cf-uaa-url))
@@ -62,14 +43,14 @@
     - name: kubeconfig
       release: kubo
       properties:
-        kubernetes-api-url: "https://((cf-tcp-router-name)):((external-kubo-port))"
+        kubernetes-api-url: "https://((kubernetes-master-host)):((kubernetes-master-port))"
         kubelet-password: ((kubelet-password))
         tls:
           kubernetes: ((tls-kubernetes))
     - name: kubernetes-proxy
       release: kubo
       properties:
-        kubernetes-api-url: "https://((cf-tcp-router-name)):((external-kubo-port))"
+        kubernetes-api-url: "https://((kubernetes-master-host)):((kubernetes-master-port))"
     - name: route-sync
       release: kubo
       properties:

--- a/manifests/ops-files/cf-routing.yml
+++ b/manifests/ops-files/cf-routing.yml
@@ -1,18 +1,18 @@
 - type: replace
   path: /variables/name=tls-kubelet/options/common_name
-  value: ((kubernetes-master-host))
+  value: ((kubernetes_master_host))
 
 - type: replace
   path: /variables/name=tls-kubelet/options/alternative_names
-  value: [((kubernetes-master-host))]
+  value: [((kubernetes_master_host))]
 
 - type: replace
   path: /variables/name=tls-kubernetes/options/common_name
-  value: ((kubernetes-master-host))
+  value: ((kubernetes_master_host))
 
 - type: replace
   path: /variables/name=tls-kubernetes/options/alternative_names
-  value: [((kubernetes-master-host))]
+  value: [((kubernetes_master_host))]
 
 - type: replace
   path: /instance_groups/name=master/jobs/-
@@ -20,7 +20,7 @@
     name: kubernetes-api-route-registrar
     release: kubo
     properties:
-      external_kubo_port: ((kubernetes-master-port))
+      external_kubo_port: ((kubernetes_master_port))
       cloud_foundry:
         api_url: ((routing-cf-api-url))
         uaa_url: ((routing-cf-uaa-url))
@@ -43,14 +43,14 @@
     - name: kubeconfig
       release: kubo
       properties:
-        kubernetes-api-url: "https://((kubernetes-master-host)):((kubernetes-master-port))"
+        kubernetes-api-url: "https://((kubernetes_master_host)):((kubernetes_master_port))"
         kubelet-password: ((kubelet-password))
         tls:
           kubernetes: ((tls-kubernetes))
     - name: kubernetes-proxy
       release: kubo
       properties:
-        kubernetes-api-url: "https://((kubernetes-master-host)):((kubernetes-master-port))"
+        kubernetes-api-url: "https://((kubernetes_master_host)):((kubernetes_master_port))"
     - name: route-sync
       release: kubo
       properties:

--- a/manifests/ops-files/haproxy.yml
+++ b/manifests/ops-files/haproxy.yml
@@ -1,0 +1,24 @@
+- type: replace
+  path: /instance_groups/-
+  value:
+      name: haproxy
+      instances: 1
+      networks:
+      - name: ((deployments_network))
+      azs: [z1]
+      stemcell: trusty
+      vm_type: common
+      jobs:
+      - name: haproxy
+        release: haproxy
+
+        properties:
+          ha_proxy:
+            backend_port: ((haproxy_tcp_backend_port))
+            tcp_link_port: ((haproxy_tcp_frontend_port))
+
+- type: replace
+  path: /releases/-
+  value:
+    name: haproxy
+    version: latest

--- a/manifests/ops-files/k8s_master_static_ip.yml
+++ b/manifests/ops-files/k8s_master_static_ip.yml
@@ -1,0 +1,4 @@
+- type: replace
+  path: /networks/type=manual/subnets/0/static
+  value:
+  - ((kubernetes-master-host))

--- a/manifests/ops-files/k8s_master_static_ip.yml
+++ b/manifests/ops-files/k8s_master_static_ip.yml
@@ -1,4 +1,4 @@
 - type: replace
   path: /networks/type=manual/subnets/0/static
   value:
-  - ((kubernetes-master-host))
+  - ((kubernetes_master_host))

--- a/manifests/ops-files/master-haproxy.yml
+++ b/manifests/ops-files/master-haproxy.yml
@@ -17,8 +17,15 @@
 
         properties:
           ha_proxy:
-            backend_port: ((master_haproxy_tcp_backend_port))
-            tcp_link_port: ((master_haproxy_tcp_frontend_port))
+            tcp_link_port: 9999 # required, but not used
+
+- type: replace
+  path: /instance_groups/name=master/jobs/name=kubernetes-api/properties/backend_port?
+  value: ((master_haproxy_tcp_backend_port))
+
+- type: replace
+  path: /instance_groups/name=master/jobs/name=kubernetes-api/properties/port?
+  value: ((master_haproxy_tcp_frontend_port))
 
 - type: replace
   path: /releases/name=haproxy?

--- a/manifests/ops-files/master-haproxy.yml
+++ b/manifests/ops-files/master-haproxy.yml
@@ -31,4 +31,6 @@
   path: /releases/name=haproxy?
   value:
     name: haproxy
+    url: https://storage.googleapis.com/kubo-releases/haproxy_tmp_v8.2.x.tgz
+    sha1: 90c314cee3551d32860ed6faf405648abae888b8
     version: latest

--- a/manifests/ops-files/master-haproxy.yml
+++ b/manifests/ops-files/master-haproxy.yml
@@ -1,7 +1,7 @@
 - type: replace
   path: /instance_groups/-
   value:
-      name: haproxy
+      name: master-haproxy
       instances: 1
       networks:
       - name: ((deployments_network))
@@ -12,13 +12,16 @@
       - name: haproxy
         release: haproxy
 
+        consumes:
+          tcp_backend: { from: master_haproxy }
+
         properties:
           ha_proxy:
-            backend_port: ((haproxy_tcp_backend_port))
-            tcp_link_port: ((haproxy_tcp_frontend_port))
+            backend_port: ((master_haproxy_tcp_backend_port))
+            tcp_link_port: ((master_haproxy_tcp_frontend_port))
 
 - type: replace
-  path: /releases/-
+  path: /releases/name=haproxy?
   value:
     name: haproxy
     version: latest

--- a/manifests/ops-files/master-haproxy.yml
+++ b/manifests/ops-files/master-haproxy.yml
@@ -5,3 +5,8 @@
 - type: replace
   path: /instance_groups/name=master/jobs/name=kubernetes-api/properties/port?
   value: ((master_haproxy_tcp_frontend_port))
+
+- type: replace
+  path: /instance_groups/name=master-haproxy/networks/0/static_ips
+  value:
+  - ((kubernetes-master-host))

--- a/manifests/ops-files/master-haproxy.yml
+++ b/manifests/ops-files/master-haproxy.yml
@@ -1,36 +1,7 @@
 - type: replace
-  path: /instance_groups/-
-  value:
-      name: master-haproxy
-      instances: 1
-      networks:
-      - name: ((deployments_network))
-      azs: [z1]
-      stemcell: trusty
-      vm_type: common
-      jobs:
-      - name: haproxy
-        release: haproxy
-
-        consumes:
-          tcp_backend: { from: master_haproxy }
-
-        properties:
-          ha_proxy:
-            tcp_link_port: 9999 # required, but not used
-
-- type: replace
   path: /instance_groups/name=master/jobs/name=kubernetes-api/properties/backend_port?
   value: ((master_haproxy_tcp_backend_port))
 
 - type: replace
   path: /instance_groups/name=master/jobs/name=kubernetes-api/properties/port?
   value: ((master_haproxy_tcp_frontend_port))
-
-- type: replace
-  path: /releases/name=haproxy?
-  value:
-    name: haproxy
-    url: https://storage.googleapis.com/kubo-releases/haproxy_tmp_v8.2.x.tgz
-    sha1: 90c314cee3551d32860ed6faf405648abae888b8
-    version: latest

--- a/manifests/ops-files/master-haproxy.yml
+++ b/manifests/ops-files/master-haproxy.yml
@@ -9,4 +9,4 @@
 - type: replace
   path: /instance_groups/name=master-haproxy/networks/0/static_ips
   value:
-  - ((kubernetes-master-host))
+  - ((kubernetes_master_host))

--- a/manifests/ops-files/remove-haproxy.yml
+++ b/manifests/ops-files/remove-haproxy.yml
@@ -1,0 +1,4 @@
+- type: remove
+  path: /instance_groups/name=master-haproxy?
+- type: remove
+  path: /releases/name=haproxy?

--- a/manifests/ops-files/worker-haproxy.yml
+++ b/manifests/ops-files/worker-haproxy.yml
@@ -11,14 +11,20 @@
       jobs:
       - name: haproxy
         release: haproxy
-
         consumes:
-          tcp_backend: { from: worker_haproxy }
-
+          tcp_backend:
+            from: worker_haproxy
         properties:
           ha_proxy:
-            backend_port: ((worker_haproxy_tcp_backend_port))
-            tcp_link_port: ((worker_haproxy_tcp_frontend_port))
+            tcp_link_port: 9999 # required, but not used
+
+- type: replace
+  path: /instance_groups/name=worker/jobs/name=kubelet/properties/backend_port?
+  value: ((worker_haproxy_tcp_backend_port))
+
+- type: replace
+  path: /instance_groups/name=worker/jobs/name=kubelet/properties/port?
+  value: ((worker_haproxy_tcp_frontend_port))
 
 - type: replace
   path: /releases/name=haproxy?

--- a/manifests/ops-files/worker-haproxy.yml
+++ b/manifests/ops-files/worker-haproxy.yml
@@ -30,4 +30,6 @@
   path: /releases/name=haproxy?
   value:
     name: haproxy
+    url: https://storage.googleapis.com/kubo-releases/haproxy_tmp_v8.2.x.tgz
+    sha1: 90c314cee3551d32860ed6faf405648abae888b8
     version: latest

--- a/manifests/ops-files/worker-haproxy.yml
+++ b/manifests/ops-files/worker-haproxy.yml
@@ -1,0 +1,27 @@
+- type: replace
+  path: /instance_groups/-
+  value:
+      name: worker-haproxy
+      instances: 1
+      networks:
+      - name: ((deployments_network))
+      azs: [z1]
+      stemcell: trusty
+      vm_type: common
+      jobs:
+      - name: haproxy
+        release: haproxy
+
+        consumes:
+          tcp_backend: { from: worker_haproxy }
+
+        properties:
+          ha_proxy:
+            backend_port: ((worker_haproxy_tcp_backend_port))
+            tcp_link_port: ((worker_haproxy_tcp_frontend_port))
+
+- type: replace
+  path: /releases/name=haproxy?
+  value:
+    name: haproxy
+    version: latest

--- a/manifests/ops-files/worker-haproxy.yml
+++ b/manifests/ops-files/worker-haproxy.yml
@@ -25,11 +25,3 @@
 - type: replace
   path: /instance_groups/name=worker/jobs/name=kubelet/properties/port?
   value: ((worker_haproxy_tcp_frontend_port))
-
-- type: replace
-  path: /releases/name=haproxy?
-  value:
-    name: haproxy
-    url: https://storage.googleapis.com/kubo-releases/haproxy_tmp_v8.2.x.tgz
-    sha1: 90c314cee3551d32860ed6faf405648abae888b8
-    version: latest

--- a/manifests/ops-files/worker-haproxy.yml
+++ b/manifests/ops-files/worker-haproxy.yml
@@ -16,6 +16,7 @@
             from: worker_haproxy
         properties:
           ha_proxy:
+            disable_http: true
             tcp_link_port: 9999 # required, but not used
 
 - type: replace

--- a/src/kubo-deployment-tests/generate_manifest_test.go
+++ b/src/kubo-deployment-tests/generate_manifest_test.go
@@ -81,7 +81,7 @@ var _ = Describe("Generate manifest", func() {
 			Entry("deployment name", "\nname: grinder\n"),
 			Entry("stemcell version", "\n  version: stemcell\\.version\\.gcp\n"),
 			Entry("network name", "\n  networks:\n  - name: network-name\n"),
-			Entry("kubernetes API URL", "\n      kubernetes-api-url: https://12\\.23\\.34\\.45:8443\n"),
+			Entry("kubernetes API URL", "\n      kubernetes-api-url: https://12\\.23\\.34\\.45:101928\n"),
 			Entry("Auto-generated kubelet password", "\n      kubelet-password: \\(\\(kubelet-password\\)\\)\n"),
 			Entry("Auto-generated admin password", "\n      admin-password: \\(\\(kubo-admin-password\\)\\)\n"),
 		)

--- a/src/kubo-deployment-tests/resources/environments/secretless/director.yml
+++ b/src/kubo-deployment-tests/resources/environments/secretless/director.yml
@@ -11,7 +11,7 @@ internal_ip: # Internal ip address of the BOSH director. Please select an availa
 
 deployments_network: network-name # Network name to deploy service in your cloud config
 
-cf-tcp-router-name: a.router.name # Hostname of TCP router. Use `cf domains` to find existing TCP domain. If none exists, see https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#shared-domains for instructions to create one.
+kubernetes-master-host: a.router.name # Hostname of TCP router. Use `cf domains` to find existing TCP domain. If none exists, see https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#shared-domains for instructions to create one.
 routing-cf-api-url: cf.api.url # TCP routing API URL. In PCF: https://api.<system domain>
 routing-cf-client-id: cf.client.id # Routing UAA client name that will be used to register tcp routes
 routing-cf-uaa-url: cf.uaa.url # Routing UAA URL In PCF: https://uaa.<system domain>
@@ -20,7 +20,7 @@ credhub_encryption_key: # 16 byte number in HEX format: i.e. ABCDEF0123456789ABC
 
 internal_cidr: # CIDR range that BOSH will deploy to
 internal_gw: # internal gateway
-external-kubo-port: 101928 # Port to use for Kubernetes API
+kubernetes-master-port: 101928 # Port to use for Kubernetes API
 
 director_name: # user friendly Director name
 dns_recursor_ip: # DNS IP address for resolving non-BOSH hostnames

--- a/src/kubo-deployment-tests/resources/environments/secretless/director.yml
+++ b/src/kubo-deployment-tests/resources/environments/secretless/director.yml
@@ -11,7 +11,7 @@ internal_ip: # Internal ip address of the BOSH director. Please select an availa
 
 deployments_network: network-name # Network name to deploy service in your cloud config
 
-kubernetes-master-host: a.router.name # Hostname of TCP router. Use `cf domains` to find existing TCP domain. If none exists, see https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#shared-domains for instructions to create one.
+kubernetes_master_host: a.router.name # Hostname of TCP router. Use `cf domains` to find existing TCP domain. If none exists, see https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#shared-domains for instructions to create one.
 routing-cf-api-url: cf.api.url # TCP routing API URL. In PCF: https://api.<system domain>
 routing-cf-client-id: cf.client.id # Routing UAA client name that will be used to register tcp routes
 routing-cf-uaa-url: cf.uaa.url # Routing UAA URL In PCF: https://uaa.<system domain>
@@ -20,7 +20,7 @@ credhub_encryption_key: # 16 byte number in HEX format: i.e. ABCDEF0123456789ABC
 
 internal_cidr: # CIDR range that BOSH will deploy to
 internal_gw: # internal gateway
-kubernetes-master-port: 101928 # Port to use for Kubernetes API
+kubernetes_master_port: 101928 # Port to use for Kubernetes API
 
 director_name: # user friendly Director name
 dns_recursor_ip: # DNS IP address for resolving non-BOSH hostnames

--- a/src/kubo-deployment-tests/resources/environments/test_gcp/director.yml
+++ b/src/kubo-deployment-tests/resources/environments/test_gcp/director.yml
@@ -11,7 +11,7 @@ internal_ip: internal.ip # Internal ip address of the BOSH director. Please sele
 
 deployments_network: network-name # Network name to deploy service in your cloud config
 
-cf-tcp-router-name: a.router.name # Hostname of TCP router. Use `cf domains` to find existing TCP domain. If none exists, see https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#shared-domains for instructions to create one.
+kubernetes-master-host: a.router.name # Hostname of TCP router. Use `cf domains` to find existing TCP domain. If none exists, see https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#shared-domains for instructions to create one.
 routing-cf-api-url: cf.api.url # TCP routing API URL. In PCF: https://api.<system domain>
 routing-cf-client-id: cf.client.id # Routing UAA client name that will be used to register tcp routes
 routing-cf-uaa-url: cf.uaa.url # Routing UAA URL In PCF: https://uaa.<system domain>
@@ -20,7 +20,7 @@ credhub_encryption_key: # 16 byte number in HEX format: i.e. ABCDEF0123456789ABC
 
 internal_cidr: # CIDR range that BOSH will deploy to
 internal_gw: # internal gateway
-external-kubo-port: 101928 # Port to use for Kubernetes API
+kubernetes-master-port: 101928 # Port to use for Kubernetes API
 
 director_name: # user friendly Director name
 dns_recursor_ip: # DNS IP address for resolving non-BOSH hostnames

--- a/src/kubo-deployment-tests/resources/environments/test_gcp/director.yml
+++ b/src/kubo-deployment-tests/resources/environments/test_gcp/director.yml
@@ -11,7 +11,6 @@ internal_ip: internal.ip # Internal ip address of the BOSH director. Please sele
 
 deployments_network: network-name # Network name to deploy service in your cloud config
 
-kubernetes-master-host: a.router.name # Hostname of TCP router. Use `cf domains` to find existing TCP domain. If none exists, see https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#shared-domains for instructions to create one.
 routing-cf-api-url: cf.api.url # TCP routing API URL. In PCF: https://api.<system domain>
 routing-cf-client-id: cf.client.id # Routing UAA client name that will be used to register tcp routes
 routing-cf-uaa-url: cf.uaa.url # Routing UAA URL In PCF: https://uaa.<system domain>
@@ -20,7 +19,6 @@ credhub_encryption_key: # 16 byte number in HEX format: i.e. ABCDEF0123456789ABC
 
 internal_cidr: # CIDR range that BOSH will deploy to
 internal_gw: # internal gateway
-kubernetes-master-port: 101928 # Port to use for Kubernetes API
 
 director_name: # user friendly Director name
 dns_recursor_ip: # DNS IP address for resolving non-BOSH hostnames
@@ -33,4 +31,4 @@ kubo_release_url: https://s3.amazonaws.com/kubo-public/kubo-release-latest.tgz
 
 routing_mode: iaas
 kubernetes_master_host: 12.23.34.45
-kubernetes_master_port: 8443
+kubernetes_master_port: 101928

--- a/src/kubo-deployment-tests/resources/environments/test_gcp_with_creds/director.yml
+++ b/src/kubo-deployment-tests/resources/environments/test_gcp_with_creds/director.yml
@@ -11,7 +11,7 @@ internal_ip: internal.ip # Internal ip address of the BOSH director. Please sele
 
 deployments_network: network-name # Network name to deploy service in your cloud config
 
-cf-tcp-router-name: a.router.name # Hostname of TCP router. Use `cf domains` to find existing TCP domain. If none exists, see https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#shared-domains for instructions to create one.
+kubernetes-master-host: a.router.name # Hostname of TCP router. Use `cf domains` to find existing TCP domain. If none exists, see https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#shared-domains for instructions to create one.
 routing-cf-api-url: cf.api.url # TCP routing API URL. In PCF: https://api.<system domain>
 routing-cf-client-id: cf.client.id # Routing UAA client name that will be used to register tcp routes
 routing-cf-uaa-url: cf.uaa.url # Routing UAA URL In PCF: https://uaa.<system domain>
@@ -20,7 +20,7 @@ credhub_encryption_key: # 16 byte number in HEX format: i.e. ABCDEF0123456789ABC
 
 internal_cidr: # CIDR range that BOSH will deploy to
 internal_gw: # internal gateway
-external-kubo-port: 101928 # Port to use for Kubernetes API
+kubernetes-master-port: 101928 # Port to use for Kubernetes API
 
 director_name: # user friendly Director name
 dns_recursor_ip: # DNS IP address for resolving non-BOSH hostnames

--- a/src/kubo-deployment-tests/resources/environments/test_gcp_with_creds/director.yml
+++ b/src/kubo-deployment-tests/resources/environments/test_gcp_with_creds/director.yml
@@ -11,7 +11,6 @@ internal_ip: internal.ip # Internal ip address of the BOSH director. Please sele
 
 deployments_network: network-name # Network name to deploy service in your cloud config
 
-kubernetes-master-host: a.router.name # Hostname of TCP router. Use `cf domains` to find existing TCP domain. If none exists, see https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#shared-domains for instructions to create one.
 routing-cf-api-url: cf.api.url # TCP routing API URL. In PCF: https://api.<system domain>
 routing-cf-client-id: cf.client.id # Routing UAA client name that will be used to register tcp routes
 routing-cf-uaa-url: cf.uaa.url # Routing UAA URL In PCF: https://uaa.<system domain>
@@ -20,7 +19,6 @@ credhub_encryption_key: # 16 byte number in HEX format: i.e. ABCDEF0123456789ABC
 
 internal_cidr: # CIDR range that BOSH will deploy to
 internal_gw: # internal gateway
-kubernetes-master-port: 101928 # Port to use for Kubernetes API
 
 director_name: # user friendly Director name
 dns_recursor_ip: # DNS IP address for resolving non-BOSH hostnames
@@ -33,4 +31,4 @@ kubo_release_url: https://s3.amazonaws.com/kubo-public/kubo-release-latest.tgz
 
 routing_mode: iaas
 kubernetes_master_host: 12.23.34.45
-kubernetes_master_port: 8443
+kubernetes_master_port: 101928

--- a/src/kubo-deployment-tests/resources/environments/test_openstack/director.yml
+++ b/src/kubo-deployment-tests/resources/environments/test_openstack/director.yml
@@ -11,7 +11,7 @@ internal_ip: # Internal ip address of the BOSH director. Please select an availa
 
 deployments_network: network-name # Network name to deploy service in your cloud config
 
-cf-tcp-router-name: a.router.name # Hostname of TCP router. Use `cf domains` to find existing TCP domain. If none exists, see https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#shared-domains for instructions to create one.
+kubernetes-master-host: a.router.name # Hostname of TCP router. Use `cf domains` to find existing TCP domain. If none exists, see https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#shared-domains for instructions to create one.
 routing-cf-api-url: cf.api.url # TCP routing API URL. In PCF: https://api.<system domain>
 routing-cf-client-id: cf.client.id # Routing UAA client name that will be used to register tcp routes
 routing-cf-uaa-url: cf.uaa.url # Routing UAA URL In PCF: https://uaa.<system domain>
@@ -20,7 +20,7 @@ credhub_encryption_key: # 16 byte number in HEX format: i.e. ABCDEF0123456789ABC
 
 internal_cidr: # CIDR range that BOSH will deploy to
 internal_gw: # internal gateway
-external-kubo-port: 101928 # Port to use for Kubernetes API
+kubernetes-master-port: 101928 # Port to use for Kubernetes API
 
 director_name: # user friendly Director name
 dns_recursor_ip: # DNS IP address for resolving non-BOSH hostnames

--- a/src/kubo-deployment-tests/resources/environments/test_openstack/director.yml
+++ b/src/kubo-deployment-tests/resources/environments/test_openstack/director.yml
@@ -11,7 +11,6 @@ internal_ip: # Internal ip address of the BOSH director. Please select an availa
 
 deployments_network: network-name # Network name to deploy service in your cloud config
 
-kubernetes-master-host: a.router.name # Hostname of TCP router. Use `cf domains` to find existing TCP domain. If none exists, see https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#shared-domains for instructions to create one.
 routing-cf-api-url: cf.api.url # TCP routing API URL. In PCF: https://api.<system domain>
 routing-cf-client-id: cf.client.id # Routing UAA client name that will be used to register tcp routes
 routing-cf-uaa-url: cf.uaa.url # Routing UAA URL In PCF: https://uaa.<system domain>
@@ -20,7 +19,6 @@ credhub_encryption_key: # 16 byte number in HEX format: i.e. ABCDEF0123456789ABC
 
 internal_cidr: # CIDR range that BOSH will deploy to
 internal_gw: # internal gateway
-kubernetes-master-port: 101928 # Port to use for Kubernetes API
 
 director_name: # user friendly Director name
 dns_recursor_ip: # DNS IP address for resolving non-BOSH hostnames
@@ -33,4 +31,4 @@ kubo_release_url: https://s3.amazonaws.com/kubo-public/kubo-release-latest.tgz
 
 routing_mode: iaas
 kubernetes_master_host: 12.23.34.45
-kubernetes_master_port: 8443
+kubernetes_master_port: 101928

--- a/src/kubo-deployment-tests/resources/environments/test_vsphere/director.yml
+++ b/src/kubo-deployment-tests/resources/environments/test_vsphere/director.yml
@@ -11,7 +11,7 @@ internal_ip: internal.ip # Internal ip address of the BOSH director. Please sele
 
 deployments_network: network-name # Network name to deploy service in your cloud config
 
-cf-tcp-router-name: a.router.name # Hostname of TCP router. Use `cf domains` to find existing TCP domain. If none exists, see https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#shared-domains for instructions to create one.
+kubernetes-master-host: a.router.name # Hostname of TCP router. Use `cf domains` to find existing TCP domain. If none exists, see https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#shared-domains for instructions to create one.
 routing-cf-api-url: cf.api.url # TCP routing API URL. In PCF: https://api.<system domain>
 routing-cf-client-id: cf.client.id # Routing UAA client name that will be used to register tcp routes
 routing-cf-uaa-url: cf.uaa.url # Routing UAA URL In PCF: https://uaa.<system domain>
@@ -20,7 +20,7 @@ credhub_encryption_key: # 16 byte number in HEX format: i.e. ABCDEF0123456789ABC
 
 internal_cidr: # CIDR range that BOSH will deploy to
 internal_gw: # internal gateway
-external-kubo-port: 101928 # Port to use for Kubernetes API
+kubernetes-master-port: 101928 # Port to use for Kubernetes API
 
 director_name: # user friendly Director name
 dns_recursor_ip: # DNS IP address for resolving non-BOSH hostnames

--- a/src/kubo-deployment-tests/resources/environments/test_vsphere/director.yml
+++ b/src/kubo-deployment-tests/resources/environments/test_vsphere/director.yml
@@ -11,7 +11,7 @@ internal_ip: internal.ip # Internal ip address of the BOSH director. Please sele
 
 deployments_network: network-name # Network name to deploy service in your cloud config
 
-kubernetes-master-host: a.router.name # Hostname of TCP router. Use `cf domains` to find existing TCP domain. If none exists, see https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#shared-domains for instructions to create one.
+kubernetes_master_host: a.router.name # Hostname of TCP router. Use `cf domains` to find existing TCP domain. If none exists, see https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#shared-domains for instructions to create one.
 routing-cf-api-url: cf.api.url # TCP routing API URL. In PCF: https://api.<system domain>
 routing-cf-client-id: cf.client.id # Routing UAA client name that will be used to register tcp routes
 routing-cf-uaa-url: cf.uaa.url # Routing UAA URL In PCF: https://uaa.<system domain>
@@ -20,7 +20,7 @@ credhub_encryption_key: # 16 byte number in HEX format: i.e. ABCDEF0123456789ABC
 
 internal_cidr: # CIDR range that BOSH will deploy to
 internal_gw: # internal gateway
-kubernetes-master-port: 101928 # Port to use for Kubernetes API
+kubernetes_master_port: 101928 # Port to use for Kubernetes API
 
 director_name: # user friendly Director name
 dns_recursor_ip: # DNS IP address for resolving non-BOSH hostnames

--- a/src/kubo-deployment-tests/resources/environments/test_vsphere_with_creds/director.yml
+++ b/src/kubo-deployment-tests/resources/environments/test_vsphere_with_creds/director.yml
@@ -11,7 +11,7 @@ internal_ip: internal.ip # Internal ip address of the BOSH director. Please sele
 
 deployments_network: network-name # Network name to deploy service in your cloud config
 
-cf-tcp-router-name: a.router.name # Hostname of TCP router. Use `cf domains` to find existing TCP domain. If none exists, see https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#shared-domains for instructions to create one.
+kubernetes-master-host: a.router.name # Hostname of TCP router. Use `cf domains` to find existing TCP domain. If none exists, see https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#shared-domains for instructions to create one.
 routing-cf-api-url: cf.api.url # TCP routing API URL. In PCF: https://api.<system domain>
 routing-cf-client-id: cf.client.id # Routing UAA client name that will be used to register tcp routes
 routing-cf-uaa-url: cf.uaa.url # Routing UAA URL In PCF: https://uaa.<system domain>
@@ -20,7 +20,7 @@ credhub_encryption_key: # 16 byte number in HEX format: i.e. ABCDEF0123456789ABC
 
 internal_cidr: # CIDR range that BOSH will deploy to
 internal_gw: # internal gateway
-external-kubo-port: 101928 # Port to use for Kubernetes API
+kubernetes-master-port: 101928 # Port to use for Kubernetes API
 
 director_name: # user friendly Director name
 dns_recursor_ip: # DNS IP address for resolving non-BOSH hostnames

--- a/src/kubo-deployment-tests/resources/environments/test_vsphere_with_creds/director.yml
+++ b/src/kubo-deployment-tests/resources/environments/test_vsphere_with_creds/director.yml
@@ -11,7 +11,7 @@ internal_ip: internal.ip # Internal ip address of the BOSH director. Please sele
 
 deployments_network: network-name # Network name to deploy service in your cloud config
 
-kubernetes-master-host: a.router.name # Hostname of TCP router. Use `cf domains` to find existing TCP domain. If none exists, see https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#shared-domains for instructions to create one.
+kubernetes_master_host: a.router.name # Hostname of TCP router. Use `cf domains` to find existing TCP domain. If none exists, see https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#shared-domains for instructions to create one.
 routing-cf-api-url: cf.api.url # TCP routing API URL. In PCF: https://api.<system domain>
 routing-cf-client-id: cf.client.id # Routing UAA client name that will be used to register tcp routes
 routing-cf-uaa-url: cf.uaa.url # Routing UAA URL In PCF: https://uaa.<system domain>
@@ -20,7 +20,7 @@ credhub_encryption_key: # 16 byte number in HEX format: i.e. ABCDEF0123456789ABC
 
 internal_cidr: # CIDR range that BOSH will deploy to
 internal_gw: # internal gateway
-kubernetes-master-port: 101928 # Port to use for Kubernetes API
+kubernetes_master_port: 101928 # Port to use for Kubernetes API
 
 director_name: # user friendly Director name
 dns_recursor_ip: # DNS IP address for resolving non-BOSH hostnames

--- a/src/kubo-deployment-tests/resources/environments/with_http_proxy/director.yml
+++ b/src/kubo-deployment-tests/resources/environments/with_http_proxy/director.yml
@@ -11,7 +11,7 @@ internal_ip: # Internal ip address of the BOSH director. Please select an availa
 
 deployments_network: network-name # Network name to deploy service in your cloud config
 
-cf-tcp-router-name: a.router.name # Hostname of TCP router. Use `cf domains` to find existing TCP domain. If none exists, see https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#shared-domains for instructions to create one.
+kubernetes-master-host: a.router.name # Hostname of TCP router. Use `cf domains` to find existing TCP domain. If none exists, see https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#shared-domains for instructions to create one.
 routing-cf-api-url: cf.api.url # TCP routing API URL. In PCF: https://api.<system domain>
 routing-cf-client-id: cf.client.id # Routing UAA client name that will be used to register tcp routes
 routing-cf-uaa-url: cf.uaa.url # Routing UAA URL In PCF: https://uaa.<system domain>
@@ -20,7 +20,7 @@ credhub_encryption_key: # 16 byte number in HEX format: i.e. ABCDEF0123456789ABC
 
 internal_cidr: # CIDR range that BOSH will deploy to
 internal_gw: # internal gateway
-external-kubo-port: 101928 # Port to use for Kubernetes API
+kubernetes-master-port: 101928 # Port to use for Kubernetes API
 
 director_name: # user friendly Director name
 dns_recursor_ip: # DNS IP address for resolving non-BOSH hostnames

--- a/src/kubo-deployment-tests/resources/environments/with_http_proxy/director.yml
+++ b/src/kubo-deployment-tests/resources/environments/with_http_proxy/director.yml
@@ -11,7 +11,6 @@ internal_ip: # Internal ip address of the BOSH director. Please select an availa
 
 deployments_network: network-name # Network name to deploy service in your cloud config
 
-kubernetes-master-host: a.router.name # Hostname of TCP router. Use `cf domains` to find existing TCP domain. If none exists, see https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#shared-domains for instructions to create one.
 routing-cf-api-url: cf.api.url # TCP routing API URL. In PCF: https://api.<system domain>
 routing-cf-client-id: cf.client.id # Routing UAA client name that will be used to register tcp routes
 routing-cf-uaa-url: cf.uaa.url # Routing UAA URL In PCF: https://uaa.<system domain>
@@ -20,7 +19,6 @@ credhub_encryption_key: # 16 byte number in HEX format: i.e. ABCDEF0123456789ABC
 
 internal_cidr: # CIDR range that BOSH will deploy to
 internal_gw: # internal gateway
-kubernetes-master-port: 101928 # Port to use for Kubernetes API
 
 director_name: # user friendly Director name
 dns_recursor_ip: # DNS IP address for resolving non-BOSH hostnames
@@ -36,4 +34,4 @@ http_proxy: my.proxy.com
 
 routing_mode: iaas
 kubernetes_master_host: 12.23.34.45
-kubernetes_master_port: 8443
+kubernetes_master_port: 101928

--- a/src/kubo-deployment-tests/resources/environments/with_https_proxy/director.yml
+++ b/src/kubo-deployment-tests/resources/environments/with_https_proxy/director.yml
@@ -11,7 +11,7 @@ internal_ip: # Internal ip address of the BOSH director. Please select an availa
 
 deployments_network: network-name # Network name to deploy service in your cloud config
 
-cf-tcp-router-name: a.router.name # Hostname of TCP router. Use `cf domains` to find existing TCP domain. If none exists, see https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#shared-domains for instructions to create one.
+kubernetes-master-host: a.router.name # Hostname of TCP router. Use `cf domains` to find existing TCP domain. If none exists, see https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#shared-domains for instructions to create one.
 routing-cf-api-url: cf.api.url # TCP routing API URL. In PCF: https://api.<system domain>
 routing-cf-client-id: cf.client.id # Routing UAA client name that will be used to register tcp routes
 routing-cf-uaa-url: cf.uaa.url # Routing UAA URL In PCF: https://uaa.<system domain>
@@ -20,7 +20,7 @@ credhub_encryption_key: # 16 byte number in HEX format: i.e. ABCDEF0123456789ABC
 
 internal_cidr: # CIDR range that BOSH will deploy to
 internal_gw: # internal gateway
-external-kubo-port: 101928 # Port to use for Kubernetes API
+kubernetes-master-port: 101928 # Port to use for Kubernetes API
 
 director_name: # user friendly Director name
 dns_recursor_ip: # DNS IP address for resolving non-BOSH hostnames

--- a/src/kubo-deployment-tests/resources/environments/with_https_proxy/director.yml
+++ b/src/kubo-deployment-tests/resources/environments/with_https_proxy/director.yml
@@ -11,7 +11,6 @@ internal_ip: # Internal ip address of the BOSH director. Please select an availa
 
 deployments_network: network-name # Network name to deploy service in your cloud config
 
-kubernetes-master-host: a.router.name # Hostname of TCP router. Use `cf domains` to find existing TCP domain. If none exists, see https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#shared-domains for instructions to create one.
 routing-cf-api-url: cf.api.url # TCP routing API URL. In PCF: https://api.<system domain>
 routing-cf-client-id: cf.client.id # Routing UAA client name that will be used to register tcp routes
 routing-cf-uaa-url: cf.uaa.url # Routing UAA URL In PCF: https://uaa.<system domain>
@@ -20,7 +19,6 @@ credhub_encryption_key: # 16 byte number in HEX format: i.e. ABCDEF0123456789ABC
 
 internal_cidr: # CIDR range that BOSH will deploy to
 internal_gw: # internal gateway
-kubernetes-master-port: 101928 # Port to use for Kubernetes API
 
 director_name: # user friendly Director name
 dns_recursor_ip: # DNS IP address for resolving non-BOSH hostnames
@@ -35,4 +33,4 @@ https_proxy: my.sslproxy.com
 
 routing_mode: iaas
 kubernetes_master_host: 12.23.34.45
-kubernetes_master_port: 8443
+kubernetes_master_port: 101928

--- a/src/kubo-deployment-tests/resources/environments/with_no_proxy/director.yml
+++ b/src/kubo-deployment-tests/resources/environments/with_no_proxy/director.yml
@@ -11,7 +11,7 @@ internal_ip: # Internal ip address of the BOSH director. Please select an availa
 
 deployments_network: network-name # Network name to deploy service in your cloud config
 
-cf-tcp-router-name: a.router.name # Hostname of TCP router. Use `cf domains` to find existing TCP domain. If none exists, see https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#shared-domains for instructions to create one.
+kubernetes-master-host: a.router.name # Hostname of TCP router. Use `cf domains` to find existing TCP domain. If none exists, see https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#shared-domains for instructions to create one.
 routing-cf-api-url: cf.api.url # TCP routing API URL. In PCF: https://api.<system domain>
 routing-cf-client-id: cf.client.id # Routing UAA client name that will be used to register tcp routes
 routing-cf-uaa-url: cf.uaa.url # Routing UAA URL In PCF: https://uaa.<system domain>
@@ -20,7 +20,7 @@ credhub_encryption_key: # 16 byte number in HEX format: i.e. ABCDEF0123456789ABC
 
 internal_cidr: # CIDR range that BOSH will deploy to
 internal_gw: # internal gateway
-external-kubo-port: 101928 # Port to use for Kubernetes API
+kubernetes-master-port: 101928 # Port to use for Kubernetes API
 
 director_name: # user friendly Director name
 dns_recursor_ip: # DNS IP address for resolving non-BOSH hostnames

--- a/src/kubo-deployment-tests/resources/environments/with_no_proxy/director.yml
+++ b/src/kubo-deployment-tests/resources/environments/with_no_proxy/director.yml
@@ -11,7 +11,6 @@ internal_ip: # Internal ip address of the BOSH director. Please select an availa
 
 deployments_network: network-name # Network name to deploy service in your cloud config
 
-kubernetes-master-host: a.router.name # Hostname of TCP router. Use `cf domains` to find existing TCP domain. If none exists, see https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#shared-domains for instructions to create one.
 routing-cf-api-url: cf.api.url # TCP routing API URL. In PCF: https://api.<system domain>
 routing-cf-client-id: cf.client.id # Routing UAA client name that will be used to register tcp routes
 routing-cf-uaa-url: cf.uaa.url # Routing UAA URL In PCF: https://uaa.<system domain>
@@ -20,7 +19,6 @@ credhub_encryption_key: # 16 byte number in HEX format: i.e. ABCDEF0123456789ABC
 
 internal_cidr: # CIDR range that BOSH will deploy to
 internal_gw: # internal gateway
-kubernetes-master-port: 101928 # Port to use for Kubernetes API
 
 director_name: # user friendly Director name
 dns_recursor_ip: # DNS IP address for resolving non-BOSH hostnames
@@ -35,4 +33,4 @@ no_proxy: dont.proxy.me
 
 routing_mode: iaas
 kubernetes_master_host: 12.23.34.45
-kubernetes_master_port: 8443
+kubernetes_master_port: 101928

--- a/src/kubo-deployment-tests/resources/environments/with_ops/director.yml
+++ b/src/kubo-deployment-tests/resources/environments/with_ops/director.yml
@@ -11,7 +11,7 @@ internal_ip: # Internal ip address of the BOSH director. Please select an availa
 
 deployments_network: network-name # Network name to deploy service in your cloud config
 
-cf-tcp-router-name: a.router.name # Hostname of TCP router. Use `cf domains` to find existing TCP domain. If none exists, see https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#shared-domains for instructions to create one.
+kubernetes-master-host: a.router.name # Hostname of TCP router. Use `cf domains` to find existing TCP domain. If none exists, see https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#shared-domains for instructions to create one.
 routing-cf-api-url: cf.api.url # TCP routing API URL. In PCF: https://api.<system domain>
 routing-cf-client-id: cf.client.id # Routing UAA client name that will be used to register tcp routes
 routing-cf-uaa-url: cf.uaa.url # Routing UAA URL In PCF: https://uaa.<system domain>
@@ -20,7 +20,7 @@ credhub_encryption_key: # 16 byte number in HEX format: i.e. ABCDEF0123456789ABC
 
 internal_cidr: # CIDR range that BOSH will deploy to
 internal_gw: # internal gateway
-external-kubo-port: 101928 # Port to use for Kubernetes API
+kubernetes-master-port: 101928 # Port to use for Kubernetes API
 
 director_name: # user friendly Director name
 dns_recursor_ip: # DNS IP address for resolving non-BOSH hostnames

--- a/src/kubo-deployment-tests/resources/environments/with_ops/director.yml
+++ b/src/kubo-deployment-tests/resources/environments/with_ops/director.yml
@@ -11,7 +11,6 @@ internal_ip: # Internal ip address of the BOSH director. Please select an availa
 
 deployments_network: network-name # Network name to deploy service in your cloud config
 
-kubernetes-master-host: a.router.name # Hostname of TCP router. Use `cf domains` to find existing TCP domain. If none exists, see https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#shared-domains for instructions to create one.
 routing-cf-api-url: cf.api.url # TCP routing API URL. In PCF: https://api.<system domain>
 routing-cf-client-id: cf.client.id # Routing UAA client name that will be used to register tcp routes
 routing-cf-uaa-url: cf.uaa.url # Routing UAA URL In PCF: https://uaa.<system domain>
@@ -20,7 +19,6 @@ credhub_encryption_key: # 16 byte number in HEX format: i.e. ABCDEF0123456789ABC
 
 internal_cidr: # CIDR range that BOSH will deploy to
 internal_gw: # internal gateway
-kubernetes-master-port: 101928 # Port to use for Kubernetes API
 
 director_name: # user friendly Director name
 dns_recursor_ip: # DNS IP address for resolving non-BOSH hostnames
@@ -33,4 +31,4 @@ kubo_release_url: https://s3.amazonaws.com/kubo-public/kubo-release-latest.tgz
 
 routing_mode: iaas
 kubernetes_master_host: 12.23.34.45
-kubernetes_master_port: 8443
+kubernetes_master_port: 101928

--- a/src/kubo-deployment-tests/resources/environments/with_vars/director.yml
+++ b/src/kubo-deployment-tests/resources/environments/with_vars/director.yml
@@ -11,7 +11,7 @@ internal_ip: # Internal ip address of the BOSH director. Please select an availa
 
 deployments_network: network-name # Network name to deploy service in your cloud config
 
-cf-tcp-router-name: a.router.name # Hostname of TCP router. Use `cf domains` to find existing TCP domain. If none exists, see https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#shared-domains for instructions to create one.
+kubernetes-master-host: a.router.name # Hostname of TCP router. Use `cf domains` to find existing TCP domain. If none exists, see https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#shared-domains for instructions to create one.
 routing-cf-api-url: cf.api.url # TCP routing API URL. In PCF: https://api.<system domain>
 routing-cf-client-id: cf.client.id # Routing UAA client name that will be used to register tcp routes
 routing-cf-uaa-url: cf.uaa.url # Routing UAA URL In PCF: https://uaa.<system domain>
@@ -20,7 +20,7 @@ credhub_encryption_key: # 16 byte number in HEX format: i.e. ABCDEF0123456789ABC
 
 internal_cidr: # CIDR range that BOSH will deploy to
 internal_gw: # internal gateway
-external-kubo-port: 101928 # Port to use for Kubernetes API
+kubernetes-master-port: 101928 # Port to use for Kubernetes API
 
 director_name: # user friendly Director name
 dns_recursor_ip: # DNS IP address for resolving non-BOSH hostnames

--- a/src/kubo-deployment-tests/resources/environments/with_vars/director.yml
+++ b/src/kubo-deployment-tests/resources/environments/with_vars/director.yml
@@ -11,7 +11,6 @@ internal_ip: # Internal ip address of the BOSH director. Please select an availa
 
 deployments_network: network-name # Network name to deploy service in your cloud config
 
-kubernetes-master-host: a.router.name # Hostname of TCP router. Use `cf domains` to find existing TCP domain. If none exists, see https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#shared-domains for instructions to create one.
 routing-cf-api-url: cf.api.url # TCP routing API URL. In PCF: https://api.<system domain>
 routing-cf-client-id: cf.client.id # Routing UAA client name that will be used to register tcp routes
 routing-cf-uaa-url: cf.uaa.url # Routing UAA URL In PCF: https://uaa.<system domain>
@@ -20,7 +19,6 @@ credhub_encryption_key: # 16 byte number in HEX format: i.e. ABCDEF0123456789ABC
 
 internal_cidr: # CIDR range that BOSH will deploy to
 internal_gw: # internal gateway
-kubernetes-master-port: 101928 # Port to use for Kubernetes API
 
 director_name: # user friendly Director name
 dns_recursor_ip: # DNS IP address for resolving non-BOSH hostnames
@@ -33,4 +31,4 @@ kubo_release_url: https://s3.amazonaws.com/kubo-public/kubo-release-latest.tgz
 
 routing_mode: iaas
 kubernetes_master_host: 12.23.34.45
-kubernetes_master_port: 8443
+kubernetes_master_port: 101928

--- a/src/kubo-deployment-tests/set_kubeconfig_test.go
+++ b/src/kubo-deployment-tests/set_kubeconfig_test.go
@@ -47,7 +47,7 @@ var _ = Describe("set_kubeconfig", func() {
 		})
 
 		It("should set cluster config on kubectl", func() {
-			Expect(stderr).To(gbytes.Say("kubectl config set-cluster deployment-name --server=https://12.23.34.45:8443"))
+			Expect(stderr).To(gbytes.Say("kubectl config set-cluster deployment-name --server=https://12.23.34.45:101928"))
 		})
 
 		It("should set credentials on kubectl", func() {


### PR DESCRIPTION
Changes on configuration and scripts to enable deployment on an OpenStack environment that requires:
- dynamic networking: revised networking configuration on both bosh and cloud config
- multi AZ: 5 AZs are configurable
- local artifacts: configurable paths (and versions and sha1) for all releases and stemcells for locked down environments with no connectivity to internet during deployment
- nova networking: included OPS file to add a flag for openstack environments still using Nova networking
- vip network for the HAProxy Floating IPs

Also added corrections to allow:
- Ops files for the KuBo manifest to make changes in the the worker-haproxy settings
- Disable HAProxy http handling