### PR TITLE
OpenStack dynamic networking setup for cloud-config and Bosh Director

### DIFF
--- a/bin/deploy_bosh
+++ b/bin/deploy_bosh
@@ -107,6 +107,7 @@ deploy_openstack() {
     --ops-file "$(repo_directory)/bosh-deployment/powerdns.yml" \
     --ops-file "$(repo_directory)/bosh-deployment/credhub.yml" \
     --ops-file "$(repo_directory)/configurations/openstack/multi-tenant.yml" \
+    --ops-file "$(repo_directory)/configurations/openstack/bosh-dynamic.yml" \
     --ops-file "$(repo_directory)/configurations/generic/bosh-admin-client.yml" \
     --state "${bosh_env}/state.json" \
     --vars-store "${bosh_env}/creds.yml" \

--- a/configurations/openstack/bosh-dynamic.yml
+++ b/configurations/openstack/bosh-dynamic.yml
@@ -1,0 +1,27 @@
+---
+- type: replace
+  path: /networks/name=default?
+  value:
+    name: default
+    type: dynamic
+    subnets:
+    - cloud_properties:
+        net_id: ((net_id))
+
+- type: replace
+  path: /networks/-
+  value:
+    name: vip
+    type: vip
+
+- type: replace
+  path: /instance_groups/name=bosh/networks/name=default?
+  value:
+    name: default
+    default: [dns, gateway]
+
+- type: replace
+  path: /instance_groups/name=bosh/networks/-
+  value:
+    name: vip
+    static_ips: [((internal_ip))]

--- a/configurations/openstack/cloud-config.yml
+++ b/configurations/openstack/cloud-config.yml
@@ -28,15 +28,11 @@ disk_types:
 networks:
 - name: ((deployments_network))
   type: dynamic
+  default: [dns, gateway]
   subnets:
-  - range: ((internal_cidr))
-    gateway: ((internal_gw))
-    azs: [z1]
-    dns: [((internal_ip))]
-    reserved:
-    - ((reserved_ips))
-    cloud_properties:
+  - cloud_properties:
       net_id: ((net_id))
+    azs: [z1]
 - name: vip
   type: vip
 


### PR DESCRIPTION
Fixed OpenStack's `cloud-config.yml` to use dynamic network properties as per documentation (http://bosh.io/docs/networks.html#dynamic).
Notice the need of the `default` property, necessary when assigning two networks to a VM
Also changed Bosh Director's configuration to dynamic networking for consistency reasons. Adding also a `vip` network in the bosh manifest and using the `internal_ip` property for Bosh's Floating IP.