### PR TITLE
Install Kubo Guide on AWS

### DIFF
--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -7,6 +7,7 @@ are GCP, vSphere and OpenStack.
 
 - [GCP](platforms/gcp/prerequisites.md)
 - [vSphere](platforms/vsphere/prerequisites.md)
+- [AWS](platforms/aws/prerequisites.md)
 
 ## Infrastructure paving
 
@@ -15,11 +16,13 @@ an environment for a Kubo deployment. Please follow the link for infrastructure
 paving on your platform:
 
 - [Google Cloud Platform](platforms/gcp/paving.md)
+- [AWS](platforms/aws/paving.md)
 
 ## Deploying BOSH
 
 - [Google Cloud Platform](platforms/gcp/install-bosh.md)
 - [vSphere](platforms/vsphere/install-bosh.md)
+- [AWS](platforms/aws/install-bosh.md)
 - [OpenStack](platforms/openstack/install-bosh.md)
 
 ## Configure Kubo
@@ -41,7 +44,8 @@ Kubo can leverage different routing options to improve security and high
 availability of the cluster. Please configure the kubo environment according
 to one of the options below:
 
-- [IaaS Load-Balancing](routing/gcp/load-balancing.md)
+- [IaaS Load-Balancing on GCP](routing/gcp/load-balancing.md)
+- [IaaS Load-Balancing on AWS](routing/aws/load-balancing.md)
 - [CF Routing](routing/cf.md)
 - [HAProxy Routing for OpenStack](routing/openstack/haproxy-routing.md)
 - [HAProxy Routing for vSphere](routing/vsphere/haproxy-routing.md)

--- a/docs/user-guide/platforms/aws/install-bosh.md
+++ b/docs/user-guide/platforms/aws/install-bosh.md
@@ -1,0 +1,55 @@
+# Deploying BOSH for KUBO on AWS
+
+1. Find the Public DNS name of the bastion instance on AWS
+
+1. SSH onto the bastion created during the [paving step](paving.md)
+
+    ```bash
+    ssh -i ~/deployer.pem ubuntu@<public DNS name>
+    ```
+    
+1. Change directory to the root of the kubo-deployment repo
+
+    ```bash
+    cd ~/kubo-deployment
+    ```
+    
+1. Create a kubo environment to set the configuration for BOSH and Kubo.
+
+    ```bash
+    export kubo_envs=~/kubo-env
+    export kubo_env_name=kubo
+    export kubo_env_path="${kubo_envs}/${kubo_env_name}"
+ 
+    mkdir -p "${kubo_envs}"
+    ./bin/generate_env_config "${kubo_envs}" ${kubo_env_name} aws
+    ```
+
+1. Apply the default networking settings by running the following line:
+
+    ```bash
+    . docs/user-guide/platforms/aws/setup_helpers
+    update_aws_env "${kubo_env_path}/director.yml" 
+    ```
+
+    The `kubo_env_path` will point to the folder containing the kubo settings,
+    and will be referred to throughout this guide as `KUBO_ENV`.
+    
+    > Alternatively, it is possible to directly edit the file located at `${kubo_env_path}/director.yml`
+
+1. Fill in `${kubo_env_path}/director-secrets.yml` with your access key id and access key secret
+
+1. Deploy a BOSH director for Kubo
+    
+    ```bash
+    ./bin/deploy_bosh "${kubo_env_path}" ~/deployer.pem
+    ```
+    Credentials and SSL certificates for the environment will be generated and
+    saved in a file called `creds.yml` located in `KUBO_ENV`. This file
+    contains sensitive information and should not be stored in VCS. The file
+    `state.json` contains 
+    [environment state for the BOSH environment](https://bosh.io/docs/cli-envs.html#deployment-state).
+
+    Subsequent runs of `bin/bosh_deploy` will apply changes made to
+    the configuration to an already existing BOSH installation, reusing
+    the credentials stored in the `creds.yml`.

--- a/docs/user-guide/platforms/aws/install-bosh.md
+++ b/docs/user-guide/platforms/aws/install-bosh.md
@@ -11,7 +11,7 @@
 1. Change directory to the root of the kubo-deployment repo
 
     ```bash
-    cd ~/kubo-deployment
+    cd /share/kubo-deployment
     ```
     
 1. Create a kubo environment to set the configuration for BOSH and Kubo.

--- a/docs/user-guide/platforms/aws/install-bosh.md
+++ b/docs/user-guide/platforms/aws/install-bosh.md
@@ -22,10 +22,10 @@
     export kubo_env_path="${kubo_envs}/${kubo_env_name}"
  
     mkdir -p "${kubo_envs}"
-    ./bin/generate_env_config "${kubo_envs}" ${kubo_env_name} aws
+    ./bin/generate_env_config "${kubo_envs}" "${kubo_env_name}" aws
     ```
 
-1. Apply the default networking settings by running the following line:
+1. Apply the default networking settings by running the following commands:
 
     ```bash
     . docs/user-guide/platforms/aws/setup_helpers

--- a/docs/user-guide/platforms/aws/kubo-infrastructre.tf
+++ b/docs/user-guide/platforms/aws/kubo-infrastructre.tf
@@ -1,0 +1,194 @@
+variable "region" {
+    type = "string"
+    default = "ca-central-1"
+}
+
+variable "zone" {
+    type = "string"
+    default = "ca-central-1b"
+}
+
+variable "public_subnet_ip_prefix" {
+    type = "string"
+    default = "10.0.1"
+}
+
+variable "private_subnet_ip_prefix" {
+    type = "string"
+    default = "10.0.2"
+}
+
+variable "key_name" {
+    type = "string"
+}
+
+variable "private_key" {
+    type = "string"
+}
+
+variable "prefix" {
+    type = "string"
+    default = ""
+}
+
+provider "aws" {
+    region = "${var.region}"
+}
+
+resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+  enable_dns_hostnames = true
+}
+
+resource "aws_internet_gateway" "gateway" {
+    vpc_id = "${aws_vpc.main.id}"
+}
+
+resource "aws_subnet" "public" {
+    vpc_id     = "${aws_vpc.main.id}"
+    cidr_block = "${var.public_subnet_ip_prefix}.0/24"
+    availability_zone = "${var.zone}"
+
+    tags {
+      Name = "Kubo Public"
+    }
+}
+
+resource "aws_route_table" "public" {
+    vpc_id = "${aws_vpc.main.id}"
+
+    route {
+      cidr_block = "0.0.0.0/0"
+      gateway_id = "${aws_internet_gateway.gateway.id}"
+    }
+}
+
+resource "aws_route_table_association" "public" {
+    subnet_id      = "${aws_subnet.public.id}"
+    route_table_id = "${aws_route_table.public.id}"
+}
+
+resource "aws_eip" "nat" {
+}
+
+resource "aws_nat_gateway" "gateway" {
+    allocation_id = "${aws_eip.nat.id}"
+    subnet_id     = "${aws_subnet.public.id}"
+}
+
+
+resource "aws_subnet" "private" {
+    vpc_id     = "${aws_vpc.main.id}"
+    cidr_block = "${var.private_subnet_ip_prefix}.0/24"
+
+    tags {
+      Name = "Kubo Private"
+    }
+}
+
+resource "aws_route_table" "private" {
+    vpc_id = "${aws_vpc.main.id}"
+
+    route {
+      cidr_block = "0.0.0.0/0"
+      gateway_id = "${aws_nat_gateway.gateway.id}"
+    }
+}
+
+resource "aws_route_table_association" "private" {
+    subnet_id      = "${aws_subnet.private.id}"
+    route_table_id = "${aws_route_table.private.id}"
+}
+
+resource "aws_security_group" "nodes" {
+    name        = "node access"
+    vpc_id = "${aws_vpc.main.id}"
+
+    ingress {
+      from_port   = 8443
+      to_port     = 8443
+      protocol    = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
+
+    egress {
+      from_port       = 0
+      to_port         = 0
+      protocol        = "-1"
+      cidr_blocks     = ["0.0.0.0/0"]
+    }
+}
+
+resource "aws_security_group_rule" "ssh" {
+    type            = "ingress"
+    from_port       = 22
+    to_port         = 22
+    protocol        = "tcp"
+    cidr_blocks     = ["0.0.0.0/0"]
+
+    security_group_id = "${aws_security_group.nodes.id}"
+}
+
+resource "aws_security_group_rule" "nodes" {
+    type            = "ingress"
+    from_port       = 0
+    to_port         = 0
+    protocol        = "-1"
+    source_security_group_id = "${aws_security_group.nodes.id}"
+
+    security_group_id = "${aws_security_group.nodes.id}"
+}
+
+data "aws_ami" "ubuntu" {
+    most_recent = true
+
+    filter {
+      name   = "name"
+      values = ["ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*"]
+    }
+
+    filter {
+      name   = "virtualization-type"
+      values = ["hvm"]
+    }
+
+    owners = ["099720109477"] # Canonical
+}
+
+resource "aws_instance" "bastion" {
+    ami           = "${data.aws_ami.ubuntu.id}"
+    instance_type = "t2.micro"
+    subnet_id     = "${aws_subnet.public.id}"
+    availability_zone = "${var.zone}"
+    key_name      = "${var.key_name}"
+    vpc_security_group_ids = ["${aws_security_group.nodes.id}"]
+    associate_public_ip_address = true
+    provisioner "remote-exec" {
+        inline = [
+            "sudo apt-get update",
+            "sudo apt-get install -y build-essential zlibc zlib1g-dev ruby ruby-dev openssl libxslt-dev libxml2-dev libssl-dev libreadline6 libreadline6-dev libyaml-dev libsqlite3-dev sqlite3",
+            "sudo apt-get install -y git",
+            "curl -L https://github.com/cloudfoundry-incubator/credhub-cli/releases/download/1.0.0/credhub-linux-1.0.0.tgz | tar zxv && chmod a+x credhub && sudo mv credhub /usr/bin",
+            "sudo curl -L https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl -o /usr/bin/kubectl && sudo chmod a+x /usr/bin/kubectl",
+            "sudo curl https://s3.amazonaws.com/bosh-cli-artifacts/bosh-cli-2.0.27-linux-amd64 -o /usr/bin/bosh-cli && sudo chmod a+x /usr/bin/bosh-cli",
+            "sudo sh -c 'sudo cat > /etc/profile.d/bosh.sh <<'EOF'",
+            "#!/bin/bash",
+            "export subnet_id=${aws_subnet.private.id}",
+            "export default_security_groups=${aws_security_group.nodes.id}",
+            "export subnet_ip_prefix=${var.private_subnet_ip_prefix}",
+            "export prefix=${var.prefix}",
+	    "export region=${var.region}",
+            "export zone=${var.zone}",
+            "EOF'",
+            "git clone https://www.github.com/cloudfoundry-incubator/kubo-deployment.git /home/ubuntu/kubo-deployment",
+            "echo \"${var.private_key}\" > /home/ubuntu/deployer.pem",
+	]
+
+        connection {
+            type     = "ssh"
+            user = "ubuntu"
+            private_key = "${var.private_key}"
+        }
+    }
+
+}

--- a/docs/user-guide/platforms/aws/kubo-infrastructre.tf
+++ b/docs/user-guide/platforms/aws/kubo-infrastructre.tf
@@ -174,6 +174,7 @@ resource "aws_instance" "bastion" {
     }
     provisioner "remote-exec" {
         inline = [
+            "set -eu",
             "sudo apt-get update",
             "sudo apt-get install -y build-essential zlibc zlib1g-dev ruby ruby-dev openssl libxslt-dev libxml2-dev libssl-dev libreadline6 libreadline6-dev libyaml-dev libsqlite3-dev sqlite3",
             "sudo apt-get install -y git",
@@ -192,12 +193,12 @@ resource "aws_instance" "bastion" {
             "export private_subnet_ip_prefix=${var.private_subnet_ip_prefix}",
             "export prefix=${var.prefix}",
             "export default_key_name=${var.key_name}",
-	    "export region=${var.region}",
+            "export region=${var.region}",
             "export zone=${var.zone}",
             "EOF'",
             "sudo mkdir /share",
-            "sudo git clone https://github.com/cloudfoundry-incubator/kubo-deployment.git /share/kubo-deployment",
-            "sudo chmod -R 777 /share",
+            "sudo chown ubuntu:ubuntu /share",
+            "git clone https://github.com/cloudfoundry-incubator/kubo-deployment.git /share/kubo-deployment",
             "echo \"${var.private_key}\" > /home/ubuntu/deployer.pem",
             "chmod 600 /home/ubuntu/deployer.pem"
 	]

--- a/docs/user-guide/platforms/aws/kubo-infrastructre.tf
+++ b/docs/user-guide/platforms/aws/kubo-infrastructre.tf
@@ -178,7 +178,7 @@ resource "aws_instance" "bastion" {
             "sudo apt-get install -y build-essential zlibc zlib1g-dev ruby ruby-dev openssl libxslt-dev libxml2-dev libssl-dev libreadline6 libreadline6-dev libyaml-dev libsqlite3-dev sqlite3",
             "sudo apt-get install -y git",
             "sudo apt-get install -y unzip",
-            "curl -L https://github.com/cloudfoundry-incubator/credhub-cli/releases/download/1.0.0/credhub-linux-1.0.0.tgz | tar zxv && chmod a+x credhub && sudo mv credhub /usr/bin",
+            "curl -L https://github.com/cloudfoundry-incubator/credhub-cli/releases/download/1.0.0/credhub-linux-1.0.0.tgz | tar zxv && sudo chmod a+x credhub && sudo mv credhub /usr/bin",
             "sudo curl -L https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl -o /usr/bin/kubectl && sudo chmod a+x /usr/bin/kubectl",
             "sudo curl https://s3.amazonaws.com/bosh-cli-artifacts/bosh-cli-2.0.27-linux-amd64 -o /usr/bin/bosh-cli && sudo chmod a+x /usr/bin/bosh-cli",
             "sudo wget https://releases.hashicorp.com/terraform/0.7.7/terraform_0.7.7_linux_amd64.zip",
@@ -196,7 +196,7 @@ resource "aws_instance" "bastion" {
             "export zone=${var.zone}",
             "EOF'",
             "sudo mkdir /share",
-            "git clone https://github.com/cloudfoundry-incubator/kubo-deployment.git /share/kubo-deployment",
+            "sudo git clone https://github.com/cloudfoundry-incubator/kubo-deployment.git /share/kubo-deployment",
             "sudo chmod -R 777 /share",
             "echo \"${var.private_key}\" > /home/ubuntu/deployer.pem",
             "chmod 600 /home/ubuntu/deployer.pem"

--- a/docs/user-guide/platforms/aws/kubo-infrastructre.tf
+++ b/docs/user-guide/platforms/aws/kubo-infrastructre.tf
@@ -54,6 +54,10 @@ resource "aws_subnet" "public" {
 resource "aws_route_table" "public" {
     vpc_id = "${var.vpc_id}"
 
+    tags {
+      Name = "${var.prefix}public-route-table"
+    }
+
     route {
       cidr_block = "0.0.0.0/0"
       gateway_id = "${aws_internet_gateway.gateway.id}"
@@ -86,6 +90,10 @@ resource "aws_subnet" "private" {
 
 resource "aws_route_table" "private" {
     vpc_id = "${var.vpc_id}"
+
+    tags {
+      Name = "${var.prefix}private-route-table"
+    }
 
     route {
       cidr_block = "0.0.0.0/0"
@@ -161,6 +169,9 @@ resource "aws_instance" "bastion" {
     key_name      = "${var.key_name}"
     vpc_security_group_ids = ["${aws_security_group.nodes.id}"]
     associate_public_ip_address = true
+    tags {
+      Name = "${var.prefix}bosh-bastion"
+    }
     provisioner "remote-exec" {
         inline = [
             "sudo apt-get update",
@@ -184,9 +195,9 @@ resource "aws_instance" "bastion" {
 	    "export region=${var.region}",
             "export zone=${var.zone}",
             "EOF'",
-            "mkdir /share",
+            "sudo mkdir /share",
             "git clone https://github.com/cloudfoundry-incubator/kubo-deployment.git /share/kubo-deployment",
-            "chmod -R 777 /share",
+            "sudo chmod -R 777 /share",
             "echo \"${var.private_key}\" > /home/ubuntu/deployer.pem",
             "chmod 600 /home/ubuntu/deployer.pem"
 	]

--- a/docs/user-guide/platforms/aws/paving.md
+++ b/docs/user-guide/platforms/aws/paving.md
@@ -18,20 +18,22 @@
   ```bash
   export AWS_ACCESS_KEY_ID=<Your AWS access key ID>
   export AWS_SECRET_ACCESS_KEY=<Your AWS secret access key>
+  export vpc_id=<An existing VPC for deploying kubo>
   export key_name=deployer
   export private_key="$(cat ~/${key_name}.pem)"
   export region=us-west-2 # region that you will deploy Kubo in
   export zone=us-west-2a # zone that you will deploy Kubo in
   export public_subnet_ip_prefix="10.0.1"
   export private_subnet_ip_prefix="10.0.2"
+  export kubo_terraform_state=~/terraform.tfstate
   ```
   
-  > When using the [CloudFoundry routing mode](../../routing/cf.md) the GCP network above 
+  > When using the [CloudFoundry routing mode](../../routing/cf.md) the VPC above 
   > needs to be the same network that CloudFoundry is using 
 
 ## Deploy supporting infrastructure
 
-This step sets up a subnetwork with a bastion VM and a set of firewall 
+This step sets up a subnetwork with a bastion VM and security group
 rules to secure access to the kubo deployment.
 
 ### Steps
@@ -49,11 +51,13 @@ rules to secure access to the kubo deployment.
   terraform apply \
     -var region="${region}" \
     -var zone="${zone}" \
+    -var vpc_id="${vpc_id}"
     -var prefix="${prefix}" \
     -var public_subnet_ip_prefix="${public_subnet_ip_prefix}" \
     -var private_subnet_ip_prefix="${private_subnet_ip_prefix}" \
     -var private_key="${private_key}" \
     -var key_name="${key_name}"
+    -state=${kubo_terraform_state}
   ```
 
 > _Note_: It's possible to preview the terraform execution plan by running the 

--- a/docs/user-guide/platforms/aws/paving.md
+++ b/docs/user-guide/platforms/aws/paving.md
@@ -19,7 +19,7 @@
   export AWS_ACCESS_KEY_ID=<Your AWS access key ID>
   export AWS_SECRET_ACCESS_KEY=<Your AWS secret access key>
   export key_name=deployer
-  export private_key="$(cat ~/deployer.pem)"
+  export private_key="$(cat ~/${key_name}.pem)"
   export region=us-west-2 # region that you will deploy Kubo in
   export zone=us-west-2a # zone that you will deploy Kubo in
   export public_subnet_ip_prefix="10.0.1"

--- a/docs/user-guide/platforms/aws/paving.md
+++ b/docs/user-guide/platforms/aws/paving.md
@@ -1,0 +1,60 @@
+# Paving the infrastructure for Kubo on AWS
+
+## Setup the shell environment
+
+1. Create an EC2 [key pair](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html) named `deployer`
+
+1. Save the key file on your machine at ~/deployer.pem
+
+1. When deploying kubo more than once, it is required to set a unique prefix
+  for every installation. Please use letters and dashes only.
+  
+  ```bash
+  export prefix=my-kubo # This prefix should be unique for every install
+  ```
+
+1. Configure the following environment variables:
+
+  ```bash
+  export AWS_ACCESS_KEY_ID=<Your AWS access key ID>
+  export AWS_SECRET_ACCESS_KEY=<Your AWS secret access key>
+  export key_name=deployer
+  export private_key="$(cat ~/deployer.pem)"
+  export region=us-west-2 # region that you will deploy Kubo in
+  export zone=us-west-2a # zone that you will deploy Kubo in
+  export public_subnet_ip_prefix="10.0.1"
+  export private_subnet_ip_prefix="10.0.2"
+  ```
+  
+  > When using the [CloudFoundry routing mode](../../routing/cf.md) the GCP network above 
+  > needs to be the same network that CloudFoundry is using 
+
+## Deploy supporting infrastructure
+
+This step sets up a subnetwork with a bastion VM and a set of firewall 
+rules to secure access to the kubo deployment.
+
+### Steps
+
+1. Clone this repository and go into the installation docs directory:
+
+  ```bash
+  git clone https://github.com/cloudfoundry-incubator/kubo-deployment.git
+  cd kubo-deployment/docs/user-guide/platforms/aws
+  ```
+
+1. Create the resources (should take between 60-90 seconds):
+
+  ```bash
+  terraform apply \
+    -var region="${region}" \
+    -var zone="${zone}" \
+    -var prefix="${prefix}" \
+    -var public_subnet_ip_prefix="${public_subnet_ip_prefix}" \
+    -var private_subnet_ip_prefix="${private_subnet_ip_prefix}" \
+    -var private_key="${private_key}" \
+    -var key_name="${key_name}"
+  ```
+
+> _Note_: It's possible to preview the terraform execution plan by running the 
+> same command, using `plan` in place of `apply`

--- a/docs/user-guide/platforms/aws/paving.md
+++ b/docs/user-guide/platforms/aws/paving.md
@@ -3,7 +3,11 @@
 ## Setup the shell environment
 
 1. Create an EC2 [key pair](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html) 
-named `deployer` and save the key file on your machine at ~/deployer.pem
+named `deployer` and save the key file on your machine at ~/deployer.pem.
+Make sure that the key has the proper permissions by running the following command:
+  ```bash
+  chmod 600 ~/deployer.pem
+  ```
 
 1. When deploying kubo more than once, it is required to set a unique prefix
   for every installation. Please use letters and dashes only.

--- a/docs/user-guide/platforms/aws/paving.md
+++ b/docs/user-guide/platforms/aws/paving.md
@@ -2,9 +2,8 @@
 
 ## Setup the shell environment
 
-1. Create an EC2 [key pair](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html) named `deployer`
-
-1. Save the key file on your machine at ~/deployer.pem
+1. Create an EC2 [key pair](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html) 
+named `deployer` and save the key file on your machine at ~/deployer.pem
 
 1. When deploying kubo more than once, it is required to set a unique prefix
   for every installation. Please use letters and dashes only.
@@ -19,13 +18,13 @@
   export AWS_ACCESS_KEY_ID=<Your AWS access key ID>
   export AWS_SECRET_ACCESS_KEY=<Your AWS secret access key>
   export vpc_id=<An existing VPC for deploying kubo>
-  export key_name=deployer
-  export private_key="$(cat ~/${key_name}.pem)"
+  export key_name=deployer # name of private key to use on Kubo VMs
+  export private_key="$(cat ~/${key_name}.pem)" # private key to use on Kubo VMs
   export region=us-west-2 # region that you will deploy Kubo in
   export zone=us-west-2a # zone that you will deploy Kubo in
-  export public_subnet_ip_prefix="10.0.1"
-  export private_subnet_ip_prefix="10.0.2"
-  export kubo_terraform_state=~/terraform.tfstate
+  export public_subnet_ip_prefix="10.0.1" # subnet that will be used for bastion VM, NAT Gateway and load balancers
+  export private_subnet_ip_prefix="10.0.2" # subnet that will be used for Kubo VMs and BOSH director
+  export kubo_terraform_state=~/terraform.tfstate 
   ```
   
   > When using the [CloudFoundry routing mode](../../routing/cf.md) the VPC above 
@@ -51,12 +50,12 @@ rules to secure access to the kubo deployment.
   terraform apply \
     -var region="${region}" \
     -var zone="${zone}" \
-    -var vpc_id="${vpc_id}"
+    -var vpc_id="${vpc_id}" \
     -var prefix="${prefix}" \
     -var public_subnet_ip_prefix="${public_subnet_ip_prefix}" \
     -var private_subnet_ip_prefix="${private_subnet_ip_prefix}" \
     -var private_key="${private_key}" \
-    -var key_name="${key_name}"
+    -var key_name="${key_name}" \
     -state=${kubo_terraform_state}
   ```
 

--- a/docs/user-guide/platforms/aws/prerequisites.md
+++ b/docs/user-guide/platforms/aws/prerequisites.md
@@ -1,0 +1,4 @@
+# Prerequisites for AWS Kubo deployment
+
+1. An existing AWS account
+1. A shell environment with the [Terraform CLI](https://www.terraform.io/docs/commands/index.html) installed

--- a/docs/user-guide/platforms/aws/prerequisites.md
+++ b/docs/user-guide/platforms/aws/prerequisites.md
@@ -2,3 +2,4 @@
 
 1. An existing AWS account
 1. A shell environment with the [Terraform CLI](https://www.terraform.io/docs/commands/index.html) installed
+1. A VPC with DNS hostnames enabled

--- a/docs/user-guide/platforms/aws/prerequisites.md
+++ b/docs/user-guide/platforms/aws/prerequisites.md
@@ -2,4 +2,5 @@
 
 1. An existing AWS account
 1. A shell environment with the [Terraform CLI](https://www.terraform.io/docs/commands/index.html) installed
-1. A VPC with DNS hostnames enabled
+1. A VPC with DNS hostnames enabled. Please make sure, when using automatic paving,
+that the VPC is not created via the "Start VPC Wizard".

--- a/docs/user-guide/platforms/aws/setup_helpers
+++ b/docs/user-guide/platforms/aws/setup_helpers
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+update_aws_env() {
+  if [[ ! -f "$1" ]] || [[ ! "$1" =~ director.yml$ ]]; then
+    echo 'Please specify the path to director.yml'
+    exit 1
+  fi
+
+  # AWS specific updates
+  sed -i -e "s/^\(region:\).*\(#.*\)/\1 ${region} \2/" "$1"
+  sed -i -e "s/^\(az:\).*\(#.*\)/\1 ${zone} \2/" "$1"
+  sed -i -e "s/^\(subnet_id:\).*\(#.*\)/\1 ${subnet_id} \2/" "$1"
+  sed -i -e "s/^\(default_key_name:\).*\(#.*\)/\1 ${default_key_name} \2/" "$1"
+  sed -i -e "s/^\(default_security_groups:\).*\(#.*\)/\1 \n- ${default_security_groups} \2/" "$1"
+  sed -i -e "s/^\(az:\).*\(#.*\)/\1 ${zone} \2/" "$1"
+  sed -i -e "s/^\(default_key_name:\).*\(#.*\)/\1 ${default_key_name} \2/" "$1"
+  # Generic updates
+  random_key=$(hexdump -n 16 -e '4/4 "%08X" 1 "\n"' /dev/urandom)
+  sed -i -e "s/^\(internal_ip:\).*\(#.*\)/\1 ${subnet_ip_prefix}.252 \2/" "$1"
+  sed -i -e "s/^\(deployments_network:\).*\(#.*\)/\1 ${prefix}kubo-network \2/" "$1"
+  sed -i -e "s/^\(credhub_encryption_key:\).*\(#.*\)/\1 ${random_key} \2/" "$1"
+  sed -i -e "s=^\(internal_cidr:\).*\(#.*\)=\1 ${subnet_ip_prefix}.0/24 \2=" "$1"
+  sed -i -e "s/^\(internal_gw:\).*\(#.*\)/\1 ${subnet_ip_prefix}.1 \2/" "$1"
+  sed -i -e "s/^\(director_name:\).*\(#.*\)/\1 ${prefix}bosh \2/" "$1"
+  sed -i -e "s/^\(dns_recursor_ip:\).*\(#.*\)/\1 ${subnet_ip_prefix}.1 \2/" "$1"
+}

--- a/docs/user-guide/platforms/aws/setup_helpers
+++ b/docs/user-guide/platforms/aws/setup_helpers
@@ -9,18 +9,30 @@ update_aws_env() {
   # AWS specific updates
   sed -i -e "s/^\(region:\).*\(#.*\)/\1 ${region} \2/" "$1"
   sed -i -e "s/^\(az:\).*\(#.*\)/\1 ${zone} \2/" "$1"
-  sed -i -e "s/^\(subnet_id:\).*\(#.*\)/\1 ${subnet_id} \2/" "$1"
+  sed -i -e "s/^\(subnet_id:\).*\(#.*\)/\1 ${private_subnet_id} \2/" "$1"
   sed -i -e "s/^\(default_key_name:\).*\(#.*\)/\1 ${default_key_name} \2/" "$1"
   sed -i -e "s/^\(default_security_groups:\).*\(#.*\)/\1 \n- ${default_security_groups} \2/" "$1"
   sed -i -e "s/^\(az:\).*\(#.*\)/\1 ${zone} \2/" "$1"
   sed -i -e "s/^\(default_key_name:\).*\(#.*\)/\1 ${default_key_name} \2/" "$1"
   # Generic updates
   random_key=$(hexdump -n 16 -e '4/4 "%08X" 1 "\n"' /dev/urandom)
-  sed -i -e "s/^\(internal_ip:\).*\(#.*\)/\1 ${subnet_ip_prefix}.252 \2/" "$1"
+  sed -i -e "s/^\(internal_ip:\).*\(#.*\)/\1 ${private_subnet_ip_prefix}.252 \2/" "$1"
   sed -i -e "s/^\(deployments_network:\).*\(#.*\)/\1 ${prefix}kubo-network \2/" "$1"
   sed -i -e "s/^\(credhub_encryption_key:\).*\(#.*\)/\1 ${random_key} \2/" "$1"
-  sed -i -e "s=^\(internal_cidr:\).*\(#.*\)=\1 ${subnet_ip_prefix}.0/24 \2=" "$1"
-  sed -i -e "s/^\(internal_gw:\).*\(#.*\)/\1 ${subnet_ip_prefix}.1 \2/" "$1"
+  sed -i -e "s=^\(internal_cidr:\).*\(#.*\)=\1 ${private_subnet_ip_prefix}.0/24 \2=" "$1"
+  sed -i -e "s/^\(internal_gw:\).*\(#.*\)/\1 ${private_subnet_ip_prefix}.1 \2/" "$1"
   sed -i -e "s/^\(director_name:\).*\(#.*\)/\1 ${prefix}bosh \2/" "$1"
-  sed -i -e "s/^\(dns_recursor_ip:\).*\(#.*\)/\1 ${subnet_ip_prefix}.1 \2/" "$1"
+  sed -i -e "s/^\(dns_recursor_ip:\).*\(#.*\)/\1 ${private_subnet_ip_prefix}.1 \2/" "$1"
+}
+
+set_iaas_routing() {
+  if [[ ! -f "$1" ]] || [[ ! "$1" =~ director.yml$ ]]; then
+    echo 'Please specify the path to director.yml'
+    exit 1
+  fi
+  sed -i -e 's/^#* *\(routing_mode:.*\)$/# \1/' "$1"
+  sed -i -e 's/^#* *\(routing_mode:\) *\(iaas\).*$/\1 \2/' "$1"
+  sed -i -e "s/^\(kubernetes_master_host:\).*\(#.*\)/\1 ${kubernetes_master_host} \2/" "$1"
+  sed -i -e "s/^\(master_target_pool:\).*\(#.*\).*$/\1 ${master_target_pool} \2/" "$1"
+  sed -i -e "s/^\(worker_target_pool:\).*\(#.*\).*$/\1 ${worker_target_pool} \2/" "$1"
 }

--- a/docs/user-guide/routing/aws/kubo-lbs.tf
+++ b/docs/user-guide/routing/aws/kubo-lbs.tf
@@ -1,0 +1,132 @@
+variable "region" {
+    type = "string"
+    default = "ca-central-1"
+}
+
+variable "vpc_id" {
+    type = "string"
+}
+
+variable node_security_group_id {
+    type = "string"
+}
+
+variable public_subnet_id {
+    type = "string"
+}
+
+provider "aws" {
+    region = "${var.region}"
+}
+
+resource "aws_security_group" "api" {
+    name        = "api access"
+    vpc_id = "${var.vpc_id}"
+
+    ingress {
+      from_port   = 8443
+      to_port     = 8443
+      protocol    = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
+
+    egress {
+      from_port       = 0
+      to_port         = 0
+      protocol        = "-1"
+      cidr_blocks     = ["0.0.0.0/0"]
+    }
+}
+
+resource "aws_security_group_rule" "api" {
+    type            = "ingress"
+    from_port       = 0
+    to_port         = 0
+    protocol        = "-1"
+    source_security_group_id = "${aws_security_group.api.id}"
+
+    security_group_id = "${var.node_security_group_id}"
+}
+
+resource "aws_elb" "api" {
+    name               = "kubo-api"
+    subnets = ["${var.public_subnet_id}"]
+    security_groups = ["${aws_security_group.api.id}"]
+
+    listener {
+      instance_port      = 8443
+      instance_protocol  = "tcp"
+      lb_port            = 8443
+      lb_protocol        = "tcp"
+    }
+
+    health_check {
+      healthy_threshold   = 2
+      unhealthy_threshold = 2
+      timeout             = 2
+      target              = "TCP:8443/"
+      interval            = 5
+    }
+}
+
+resource "aws_security_group" "apps" {
+    name        = "apps access"
+    vpc_id = "${var.vpc_id}"
+
+    ingress {
+      from_port   = 30000
+      to_port     = 32000
+      protocol    = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
+
+    egress {
+      from_port       = 0
+      to_port         = 0
+      protocol        = "-1"
+      cidr_blocks     = ["0.0.0.0/0"]
+    }
+}
+
+resource "aws_security_group_rule" "apps" {
+    type            = "ingress"
+    from_port       = 0
+    to_port         = 0
+    protocol        = "-1"
+    source_security_group_id = "${aws_security_group.apps.id}"
+
+    security_group_id = "${var.node_security_group_id}"
+}
+
+resource "aws_elb" "apps" {
+    name               = "kubo-apps"
+    subnets = ["${var.public_subnet_id}"]
+    security_groups = ["${aws_security_group.apps.id}"]
+
+    listener {
+      instance_port      = 31000
+      instance_protocol  = "tcp"
+      lb_port            = 31000
+      lb_protocol        = "tcp"
+    }
+
+    health_check {
+      healthy_threshold   = 2
+      unhealthy_threshold = 2
+      timeout             = 2
+      target              = "TCP:22/"
+      interval            = 5
+    }
+}
+
+output "kubo_master_target_pool" {
+   value = "${aws_elb.api.name}"
+}
+
+output "master_lb_ip_address" {
+  value = "${aws_elb.api.dns_name}"
+}
+
+output "kubo_worker_target_pool" {
+   value = "${aws_elb.apps.name}"
+}

--- a/docs/user-guide/routing/aws/kubo-lbs.tf
+++ b/docs/user-guide/routing/aws/kubo-lbs.tf
@@ -1,17 +1,20 @@
 variable "region" {
     type = "string"
-    default = "ca-central-1"
 }
 
 variable "vpc_id" {
     type = "string"
 }
 
-variable node_security_group_id {
+variable "node_security_group_id" {
     type = "string"
 }
 
-variable public_subnet_id {
+variable "public_subnet_id" {
+    type = "string"
+}
+
+variable "prefix" {
     type = "string"
 }
 
@@ -20,7 +23,7 @@ provider "aws" {
 }
 
 resource "aws_security_group" "api" {
-    name        = "api access"
+    name        = "${var.prefix}api-access"
     vpc_id = "${var.vpc_id}"
 
     ingress {
@@ -49,7 +52,7 @@ resource "aws_security_group_rule" "api" {
 }
 
 resource "aws_elb" "api" {
-    name               = "kubo-api"
+    name               = "${var.prefix}kubo-api"
     subnets = ["${var.public_subnet_id}"]
     security_groups = ["${aws_security_group.api.id}"]
 
@@ -70,7 +73,7 @@ resource "aws_elb" "api" {
 }
 
 resource "aws_security_group" "apps" {
-    name        = "apps access"
+    name        = "${var.prefix}apps-access"
     vpc_id = "${var.vpc_id}"
 
     ingress {
@@ -99,7 +102,7 @@ resource "aws_security_group_rule" "apps" {
 }
 
 resource "aws_elb" "apps" {
-    name               = "kubo-apps"
+    name               = "${var.prefix}kubo-apps"
     subnets = ["${var.public_subnet_id}"]
     security_groups = ["${aws_security_group.apps.id}"]
 

--- a/docs/user-guide/routing/aws/kubo-lbs.tf
+++ b/docs/user-guide/routing/aws/kubo-lbs.tf
@@ -67,7 +67,7 @@ resource "aws_elb" "api" {
       healthy_threshold   = 2
       unhealthy_threshold = 2
       timeout             = 2
-      target              = "TCP:8443/"
+      target              = "TCP:8443"
       interval            = 5
     }
 }
@@ -78,7 +78,7 @@ resource "aws_security_group" "apps" {
 
     ingress {
       from_port   = 30000
-      to_port     = 32000
+      to_port     = 32767
       protocol    = "tcp"
       cidr_blocks = ["0.0.0.0/0"]
     }
@@ -117,7 +117,7 @@ resource "aws_elb" "apps" {
       healthy_threshold   = 2
       unhealthy_threshold = 2
       timeout             = 2
-      target              = "TCP:22/"
+      target              = "TCP:22"
       interval            = 5
     }
 }

--- a/docs/user-guide/routing/aws/load-balancing.md
+++ b/docs/user-guide/routing/aws/load-balancing.md
@@ -34,6 +34,7 @@ setup the Load balancers:
       -var vpc_id=${vpc_id} \
       -var node_security_group_id=${default_security_groups} \
       -var public_subnet_id=${public_subnet_id} \
+      -var prefix=${prefix} \
       -state=${kubo_terraform_state}
    ```
 
@@ -48,7 +49,7 @@ setup the Load balancers:
 1. Update the Kubo environment using the following snippet:
 
    ```bash
-   . ~/kubo-deployment/docs/user-guide/platforms/aws/setup_helpers
+   . /share/kubo-deployment/docs/user-guide/platforms/aws/setup_helpers
    set_iaas_routing "${state_dir}/director.yml"
    ```
    

--- a/docs/user-guide/routing/aws/load-balancing.md
+++ b/docs/user-guide/routing/aws/load-balancing.md
@@ -1,0 +1,55 @@
+# Configuring IaaS routing for Kubo
+
+On platforms that support native load-balancers kubo can be configured to leverage the
+IaaS load balancers. Currently, only the GCP and AWS platforms are supported.
+
+## Prerequisites
+
+Before deploying and configuring Kubo, you need to carry out the following steps to 
+setup the Load balancers:
+   
+1. This guide expects to be run in the same bash session as the [BOSH install](../../platforms/aws/install-bosh.md).
+   If, for some reason, that is not the case, please set the `kubo_env_name` variable to the name
+   of the Kubo environment before running the rest of the scripts.
+   
+
+1. On the BOSH bastion `cd` into the guide directory
+
+   ```bash
+   cd /share/kubo-deployment/docs/user-guide/routing/aws
+   ```
+
+1. Export these values. If you haven't tweaked any settings then use these defaults:
+
+   ```bash
+   export state_dir=~/kubo-env/${kubo_env_name}
+   export kubo_terraform_state=${state_dir}/terraform.tfstate
+   ``` 
+
+1. Create the resources
+   
+   ```bash
+   terraform apply \
+      -var region=${region} \
+      -var vpc_id=${vpc_id} \
+      -var node_security_group_id=${default_security_groups} \
+      -var public_subnet_id=${public_subnet_id} \
+      -state=${kubo_terraform_state}
+   ```
+
+1. To get the outputs for the configuration files, run the following snippet:
+   
+   ```bash
+   export master_target_pool=$(terraform output -state=${kubo_terraform_state} kubo_master_target_pool) # master_target_pool                                                                             
+   export worker_target_pool=$(terraform output -state=${kubo_terraform_state} kubo_worker_target_pool) # worker_target_pool
+   export kubernetes_master_host=$(terraform output -state=${kubo_terraform_state} master_lb_ip_address) # kubernetes_master_host
+   ```
+
+1. Update the Kubo environment using the following snippet:
+
+   ```bash
+   . ~/kubo-deployment/docs/user-guide/platforms/aws/setup_helpers
+   set_iaas_routing "${state_dir}/director.yml"
+   ```
+   
+   > It is also possible to set the configuration manually by editing the <KUBO_ENV>/director.yml  

--- a/docs/user-guide/routing/aws/load-balancing.md
+++ b/docs/user-guide/routing/aws/load-balancing.md
@@ -26,6 +26,13 @@ setup the Load balancers:
    export kubo_terraform_state=${state_dir}/terraform.tfstate
    ``` 
 
+1. Export your AWS credentials so that Terraform can use them:
+
+   ```bash
+   export AWS_ACCESS_KEY_ID=<Your AWS access key ID>
+   export AWS_SECRET_ACCESS_KEY=<Your AWS secret access key>
+   ``` 
+
 1. Create the resources
    
    ```bash

--- a/docs/user-guide/routing/exposing-apps.md
+++ b/docs/user-guide/routing/exposing-apps.md
@@ -15,3 +15,15 @@ You can access the service using the external IP address of the  `kubo-workers` 
 balancer and the `NodePort` of your service.
 
 1. Access your service from your browser at `<IP address of the load balancer>:<NodePort>`
+
+## Accessing an application on AWS with IaaS Load-Balancing
+
+An additional load balancer is provisioned using Terraform during the setup in our guide.
+You can access the service using the external IP address of the  `kubo-apps` load
+balancer and the `NodePort` of your service.
+
+1. Add a listener on the `kubo-workers` load balancer for the `NodePort` of your service
+
+1. Find the DNS name of your load balancer in the Description section
+
+1. Access your service at `<DNS name of load balancer>:<NodePort>`


### PR DESCRIPTION
Included in this PR:

- Prerequisites doc
- Paving guide and Terraform script, including bastion setup in Terraform
- Helper scripts for setting up the env config
- Install BOSH guide
- iaas routing guide and Terraform script, which deploys a Load Balancer for Kubernetes worker nodes
- Links to above docs in main README
- Additional section in accessing cluster guide

Not included: 

- AWS cloud config settings for services of type LoadBalancer
- AWS cloud config settings for persistent volumes
- Actual health checks for the nodes. Currently, the health checks just check if the nodes are up and running, not if the nodes are actually running Kubernetes.

To test this, I manually ran through the instructions to deploy a cluster with iaas routing, ran nginx on the cluster and accessed the nginx welcome page from outside of the Kubo network.