### PR TITLE
Add k8s cloud config value for LoadBalancer support

### DIFF
--- a/bin/lib/deploy_utils
+++ b/bin/lib/deploy_utils
@@ -56,7 +56,6 @@ upload_release() {
   BOSH_ENVIRONMENT="${BOSH_NAME}" BOSH_CLIENT=bosh_admin BOSH_CLIENT_SECRET=$(get_bosh_secret)  bosh-cli upload-release "$release_name"
 }
 
-
 generate_manifest() {
   if [ $# -ne 4 ]; then
     echo "Required arguments are <path to kubo bosh environment>, <deployment name>, <base manifest path> and <director uuid> in ${BASH_SOURCE[0]}:generate_manifest()"
@@ -88,7 +87,6 @@ generate_manifest() {
   if bosh-cli int "${bosh_environment}/director.yml" --path='/no_proxy' &>/dev/null; then
     manifest=$(bosh-cli int <(echo "$manifest") --ops-file="${manifest_dir}/ops-files/add-no-proxy.yml")
   fi
-
 
   case "$routing_mode" in
     cf)

--- a/configurations/gcp/project-config.yml
+++ b/configurations/gcp/project-config.yml
@@ -6,3 +6,4 @@ tags: # tags below are used if jumpbox and NAT were deployed using https://githu
   - internal # allow access to the instances in same network from BOSH
 zone: # name of GCP zone
 service_account: # service account to set as default on Kubo VMs
+worker_node_tag: # A tag that uniquely identifies worker nodes in this deployment. 

--- a/docs/user-guide/platforms/gcp/kubo-infrastructre.tf
+++ b/docs/user-guide/platforms/gcp/kubo-infrastructre.tf
@@ -71,6 +71,14 @@ data "google_iam_policy" "admin" {
   }
 
   binding {
+    role = "roles/compute.securityAdmin"
+
+    members = [
+      "serviceAccount:${google_service_account.kubo.email}",
+    ]
+  }
+
+  binding {
     role = "roles/compute.instanceAdmin"
 
     members = [
@@ -222,6 +230,7 @@ sed -i -e 's/^\(network:\).*\(#.*\)/\1 ${var.network} \2/' "$1"
 sed -i -e 's/^\(subnetwork:\).*\(#.*\)/\1 ${google_compute_subnetwork.kubo-subnet.name} \2/' "$1"
 sed -i -e 's/^\(zone:\).*\(#.*\)/\1 ${var.zone} \2/' "$1"
 sed -i -e 's/^\(service_account:\).*\(#.*\)/\1 ${google_service_account.kubo.email} \2/' "$1"
+sed -i -e 's/^\(worker_node_tag:\).*\(#.*\)/\1 ${var.prefix}bosh-kubo-worker \2/' "$1"
 
 # Generic updates
 random_key=$$(hexdump -n 16 -e '4/4 "%08X" 1 "\n"' /dev/urandom)
@@ -250,7 +259,6 @@ sed -i -e 's/^#* *\(routing_mode:\) *\(iaas\).*$/\1 \2/' "$1"
 
 sed -i -e "s/^\(kubernetes_master_host:\).*\(#.*\)/\1 $${kubernetes_master_host} \2/" "$1"
 sed -i -e "s/^\(master_target_pool:\).*\(#.*\).*$/\1 $${master_target_pool} \2/" "$1"
-sed -i -e "s/^\(worker_target_pool:\).*\(#.*\).*$/\1 $${worker_target_pool} \2/" "$1"
 
 EOF
 chmod a+x /usr/bin/set_iaas_routing

--- a/docs/user-guide/routing/exposing-apps.md
+++ b/docs/user-guide/routing/exposing-apps.md
@@ -2,7 +2,7 @@
 
 ## Accessing an application on GCP with IaaS Load-Balancing
 
-You can expose routes using the service type NodePort or LoadBalancer for your Kubernetes deployments. See the [Kubernetes docs](https://kubernetes.io/docs/tutorials/kubernetes-basics/expose-intro/) for more details.
+You can expose routes using the service type LoadBalancer for your Kubernetes deployments. See the [Kubernetes docs](https://kubernetes.io/docs/tutorials/kubernetes-basics/expose-intro/) for more details.
 
 > **Note:** Any resources that are provisioned by Kubernetes will not be deleted by BOSH when you delete your Kubo deployment. You will need to manage these resources if they are not deleted by Kubernetes before the deployment is deleted.
 

--- a/docs/user-guide/routing/exposing-apps.md
+++ b/docs/user-guide/routing/exposing-apps.md
@@ -1,20 +1,10 @@
 # Exposing deployed applications directly
 
-The only way to expose Kubernetes applications running in Kubo is to use a 
-[`NodePort`](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport). 
-
-We do not currently support the type [`LoadBalancer`](https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer),
-but we plan to soon with Github issue [#47](https://github.com/cloudfoundry-incubator/kubo-release/issues/47)
-in the [kubo-release](https://github.com/cloudfoundry-incubator/kubo-release) 
-repository. 
-
 ## Accessing an application on GCP with IaaS Load-Balancing
 
-An additional load balancer is provisioned using Terraform during the setup in our guide. 
-You can access the service using the external IP address of the  `kubo-workers` load 
-balancer and the `NodePort` of your service.
+You can expose routes using the service type NodePort or LoadBalancer for your Kubernetes deployments. See the [Kubernetes docs](https://kubernetes.io/docs/tutorials/kubernetes-basics/expose-intro/) for more details.
 
-1. Access your service from your browser at `<IP address of the load balancer>:<NodePort>`
+> **Note:** Any resources that are provisioned by Kubernetes will not be deleted by BOSH when you delete your Kubo deployment. You will need to manage these resources if they are not deleted by Kubernetes before the deployment is deleted.
 
 ## Accessing an application on AWS with IaaS Load-Balancing
 

--- a/docs/user-guide/routing/gcp/kubo-lbs.tf
+++ b/docs/user-guide/routing/gcp/kubo-lbs.tf
@@ -58,46 +58,10 @@ resource "google_compute_firewall" "kubo-tcp-public" {
   target_tags = ["master"]
 }
 
-
-// Static IP address for HTTP forwarding rule
-resource "google_compute_address" "kubo-workers-tcp" {
-  name = "${var.prefix}kubo-workers"
-}
-
-// TCP Load Balancer
-resource "google_compute_target_pool" "kubo-workers-tcp-public" {
-    region = "${var.region}"
-    name = "${var.prefix}kubo-workers-tcp-public"
-}
-
-resource "google_compute_forwarding_rule" "kubo-workers-tcp" {
-  name        = "${var.prefix}kubo-workers-tcp"
-  target      = "${google_compute_target_pool.kubo-workers-tcp-public.self_link}"
-  port_range  = "30000-32767"
-  ip_protocol = "TCP"
-  ip_address  = "${google_compute_address.kubo-workers-tcp.address}"
-}
-
-resource "google_compute_firewall" "kubo-workers-tcp-public" {
-  name    = "${var.prefix}kubo-workers-tcp-public"
-  network       = "${var.network}"
-
-  allow {
-    protocol = "tcp"
-    ports    = ["30000-32767"]
-  }
-
-  target_tags = ["worker"]
-}
-
 output "kubo_master_target_pool" {
    value = "${google_compute_target_pool.kubo-tcp-public.name}"
 }
 
 output "master_lb_ip_address" {
   value = "${google_compute_address.kubo-tcp.address}"
-}
-
-output "kubo_worker_target_pool" {
-   value = "${google_compute_target_pool.kubo-workers-tcp-public.name}"
 }

--- a/docs/user-guide/routing/gcp/load-balancing.md
+++ b/docs/user-guide/routing/gcp/load-balancing.md
@@ -4,9 +4,13 @@ On platforms that support native load-balancers kubo can be configured to levera
 
 ## Prerequisites
 
-Before deploying and configuring Kubo, you need to carry out the following steps to setup the Load balancers:
-
-1. This guide expects the same environment variables to be available as the [BOSH install guide](../../platforms/gcp/install-bosh.md). If you're not continuing from that guide, be careful in the steps below not to use an unset environment variable.
+Before deploying and configuring Kubo, you need to carry out the following steps to 
+setup the Load balancer:
+   
+1. This guide expects to be run in the same bash session as the [BOSH install](../../platforms/gcp/install-bosh.md).
+   If, for some reason, that is not the case, please set the `kubo_env_name` variable to the name
+   of the Kubo environment before running the rest of the scripts.
+   
 
 1. On the BOSH bastion, change directory into the guide:
 
@@ -33,14 +37,12 @@ Before deploying and configuring Kubo, you need to carry out the following steps
         -state=${kubo_terraform_state}
     ```
 
-1. Export the outputs from the Terraform configuration:
-
-    ```bash
-    export master_target_pool=$(terraform output -state=${kubo_terraform_state} kubo_master_target_pool) # master_target_pool
-
-    export worker_target_pool=$(terraform output -state=${kubo_terraform_state} kubo_worker_target_pool) # worker_target_pool
-    export kubernetes_master_host=$(terraform output -state=${kubo_terraform_state} master_lb_ip_address) # kubernetes_master_host
-    ```
+1. To get the outputs for the configuration files, run the following snippet:
+   
+   ```bash
+   export master_target_pool=$(terraform output -state=${kubo_terraform_state} kubo_master_target_pool) # master_target_pool                                                                             
+   export kubernetes_master_host=$(terraform output -state=${kubo_terraform_state} master_lb_ip_address) # kubernetes_master_host
+   ```
 
 1. Update the Kubo environment:
 
@@ -48,4 +50,4 @@ Before deploying and configuring Kubo, you need to carry out the following steps
     /usr/bin/set_iaas_routing "${state_dir}/director.yml"
     ```
 
-    > **Note:** You can also set the configuration manually by editing <KUBO_ENV>/director.yml  
+    > **Note:** You can also set the configuration manually by editing <KUBO_ENV>/director.yml

--- a/manifests/ops-files/gcp-cloud-provider.yml
+++ b/manifests/ops-files/gcp-cloud-provider.yml
@@ -5,6 +5,7 @@
     gce:
       project-id: ((project_id))
       network-name: ((network))
+      worker-node-tag: ((worker_node_tag))
 - type: replace
   path: /instance_groups/name=master/jobs/name=cloud-provider/properties/cloud-provider?
   value:
@@ -12,3 +13,4 @@
     gce:
       project-id: ((project_id))
       network-name: ((network))
+      worker-node-tag: ((worker_node_tag))

--- a/manifests/ops-files/load_balancer_target_pools.yml
+++ b/manifests/ops-files/load_balancer_target_pools.yml
@@ -1,6 +1,3 @@
 - type: replace
   path: /vm_types/name=master/cloud_properties/target_pool?
   value: ((master_target_pool))
-- type: replace
-  path: /vm_types/name=worker/cloud_properties/target_pool?
-  value: ((worker_target_pool))

--- a/src/kubo-deployment-tests/generate_cloud_config_test.go
+++ b/src/kubo-deployment-tests/generate_cloud_config_test.go
@@ -38,14 +38,12 @@ var _ = Describe("Generate cloud config", func() {
 		bash.Run("main", []string{filepath.Join(testEnvironmentPath, "test_vsphere")})
 
 		Expect(stdout).NotTo(gbytes.Say("    target_pool: \\(\\(master_target_pool\\)\\)"))
-		Expect(stdout).NotTo(gbytes.Say("    target_pool: \\(\\(worker_target_pool\\)\\)"))
 	})
 
 	It("includes load balancer configuration for iaas-based environment", func() {
 		bash.Run("main", []string{kuboEnv})
 
 		Expect(stdout).To(gbytes.Say("    target_pool: \\(\\(master_target_pool\\)\\)"))
-		Expect(stdout).To(gbytes.Say("    target_pool: \\(\\(worker_target_pool\\)\\)"))
 	})
 
 	It("fails with no arguments", func() {


### PR DESCRIPTION
Included:

- Adds the worker-node-tag field to the cloud-provider job so that the cloud-provider job can put the tag in the k8s cloud-config
- Removes the worker load balancer, which is no longer necessary
- Adds the securityAdmin role to the kubernetes node's service account, which is necessary to create firewall rules
- Tests are [here](https://github.com/pivotal-cf-experimental/kubo-ci/pull/7), these PRs will need to be merged at the same time
- Pipeline is [here](https://ci.kubo.sh/teams/main/pipelines/kubo-deployment-current-branch-mkjelland-2). Currently there is 1 failing test in vsphere, but this test is failing in other branches too and is unrelated to these changes.