### PR TITLE
Bumping CPUs for workers in vSphere

### DIFF
--- a/configurations/vsphere/cloud-config.yml
+++ b/configurations/vsphere/cloud-config.yml
@@ -34,7 +34,7 @@ vm_types:
 - name: worker
   cloud_properties:
     ram: 8192
-    cpu: 1
+    cpu: 4
     disk: 102400
 
 disk_types:


### PR DESCRIPTION
Adding more vCPUs to the Workers for vSphere deployments. Aligning it with other IaaS worker specs (e.g: [OpenStack](https://github.com/jaimegag/kubo-deployment/blob/master/configurations/openstack/cloud-config.yml#L19) m1.large = 4 vCPU - 8GB RAM)
[AWS](https://github.com/jaimegag/kubo-deployment/blob/master/configurations/aws/cloud-config.yml#L23) (m4.xlarge) has also 4 vCPUs though more RAM (16 GB)
[GCP](https://github.com/jaimegag/kubo-deployment/blob/master/configurations/gcp/cloud-config.yml#L40) (n1-standard-2) has 2 vCPU. This could be bumped also but since it has a direct $$ impact I didn't change it.