### PR TITLE
Add Cloud Resource Manager API enabled as a GCP prerequisite

### DIFF
--- a/docs/user-guide/platforms/gcp/prerequisites.md
+++ b/docs/user-guide/platforms/gcp/prerequisites.md
@@ -2,4 +2,4 @@
 
 1. An existing GCP project
 1. A user account with the [owner role](https://cloud.google.com/iam/docs/understanding-roles) in the GCP project
-1. [IAM API](https://console.cloud.google.com/apis/api/iam.googleapis.com/overview) must be enabled for the GCP project.
+1. [IAM](https://console.cloud.google.com/apis/api/iam.googleapis.com/overview) and [Resource Manager](https://console.developers.google.com/apis/api/cloudresourcemanager.googleapis.com/overview) APIs must be enabled for the GCP project.


### PR DESCRIPTION
Following the [Paving the Infrastructure for Kubo on GCP](https://github.com/cloudfoundry-incubator/kubo-deployment/blob/master/docs/user-guide/platforms/gcp/paving.md) instructions I ran into this error:

```
Error applying plan:
1 error(s) occurred:
* google_service_account.kubo: 1 error(s) occurred:

* google_project_iam_policy.policy: Error retrieving IAM policy for project "[REDACTED]": googleapi: 
Error 403: Google Cloud Resource Manager API has not been used in project [REDACTED] before
or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/cloudresourcemanager.googleapis.com/overview?project=[REDACTED] 
then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our 
systems and retry., accessNotConfigured
```

This PR adds [Resource Manager](https://console.developers.google.com/apis/api/cloudresourcemanager.googleapis.com/overview) as a prerequisite.