### PR TITLE
Fix GCP paving instructions: GCP subnet is created by terraform

### DIFF
--- a/docs/user-guide/platforms/gcp/paving.md
+++ b/docs/user-guide/platforms/gcp/paving.md
@@ -11,7 +11,7 @@
     export prefix=my-kubo # This prefix should be unique for every install
     ```
 
-1. Create a GCP network using the [GCP dashboard](https://console.cloud.google.com). Then create a new subnet with a CIDR range with a mask exactly 24-bits large. In the example below, we're using a subnet with CIDR range `10.0.1.0/24`.
+1. Create a GCP network using the [GCP dashboard](https://console.cloud.google.com). Configure a CIDR range with a mask exactly 24-bits large for a GCP subnet (it will be automatically created later). In the example below, we're using a subnet with CIDR range `10.0.1.0/24`.
 
     Export environment variables for these resources:
 


### PR DESCRIPTION
The [Paving the Infrastructure for Kubo on GCP](https://github.com/cloudfoundry-incubator/kubo-deployment/blob/master/docs/user-guide/platforms/gcp/paving.md) instructions suggests creating a new subnet, but the subnet is [created by terraform](https://github.com/cloudfoundry-incubator/kubo-deployment/blob/master/docs/user-guide/platforms/gcp/kubo-infrastructre.tf#L108).

Worth noting that if https://github.com/cloudfoundry-incubator/kubo-deployment/pull/146 is merged then the doc should be updated again.