### PR TITLE
Use `elbs` in `vm_extensions` for `vm_types`

### DIFF
--- a/manifests/ops-files/aws-lb-cloud-config.yml
+++ b/manifests/ops-files/aws-lb-cloud-config.yml
@@ -1,3 +1,3 @@
 - type: replace
-  path: /vm_types/name=master/cloud_properties/elbs?
+  path: /vm_extensions/name=master/cloud_properties/elbs?
   value: [((master_target_pool))]


### PR DESCRIPTION
According to the BOSH documentation [here](https://bosh.io/docs/cloud-config.html#vm-extensions) `elbs` are part of `vm_extensions` but not `vm_types`. Let me know if am missing anything. I faced error when using this cloud-config.yml to update my cloud-config.