### PR TITLE
Use static name with internal domain for kubelet certificate

### DIFF
--- a/manifests/kubo.yml
+++ b/manifests/kubo.yml
@@ -168,8 +168,7 @@ variables:
   type: certificate
   options:
     ca: kubo_ca
-    common_name: ((kubernetes_master_host))
-    alternative_names: [((kubernetes_master_host))]
+    common_name: kubelet.kubo.internal
     organization: "system:nodes"
 - name: tls-kubernetes
   type: certificate

--- a/manifests/kubo.yml
+++ b/manifests/kubo.yml
@@ -169,6 +169,7 @@ variables:
   options:
     ca: kubo_ca
     common_name: kubelet.kubo.internal
+    alternative_names: []
     organization: "system:nodes"
 - name: tls-kubernetes
   type: certificate


### PR DESCRIPTION
Signed-off-by: Oleksandr Slynko <oslynko@pivotal.io>