### PR TITLE
Fix the default kubo.yml to not compiled versions

### DIFF
--- a/bin/lib/deploy_utils
+++ b/bin/lib/deploy_utils
@@ -136,5 +136,16 @@ generate_manifest() {
     manifest=$(bosh-cli int <(echo "${manifest}") --vars-file="${bosh_environment}/director-secrets.yml")
   fi
 
+  if [[ ! -z "${ADDITIONAL_MANIFEST_OPS_FILES}" ]]; then
+    local ops_string=""
+    while IFS=':' read -ra additional_manifest_ops_files; do
+      for ops_file in ${additional_manifest_ops_files[@]}; do
+        ops_string="${ops_string} --ops-file=${ops_file}"
+      done
+    done <<< "${ADDITIONAL_MANIFEST_OPS_FILES}"
+
+    manifest=$(bosh-cli int <(echo "${manifest}") ${ops_string} --vars-file ${bosh_environment}/director.yml)
+  fi
+
   printf "%s" "${manifest}"
 }

--- a/manifests/kubo.yml
+++ b/manifests/kubo.yml
@@ -6,14 +6,14 @@ features:
 releases:
 - name: kubo-etcd
   version: 2
-  url: https://storage.googleapis.com/kubo-public/kubo-etcd-2-ubuntu-trusty-3468.5-20171107-125206-82655546-20171107125213.tgz
-  sha1: 044b7a019baae96e97adc7a19da84c64d949a763
+  url: https://github.com/pivotal-cf-experimental/kubo-etcd/releases/download/v2/kubo-etcd.2.tgz
+  sha1: ae95e661cd9df3bdc59ee38bf94dd98e2f280d4f
 - name: kubo
   version: latest
 - name: docker
   version: 28.0.1
-  url: https://storage.googleapis.com/kubo-public/docker-28.0.1-ubuntu-trusty-3468.5-20171107-125514-444936754-20171107125523.tgz
-  sha1: 985e7d430f97cc8a95b539c1bdd04be0d55c10bd
+  url: https://bosh.io/d/github.com/cf-platform-eng/docker-boshrelease?v=28.0.1
+  sha1: 448eaa2f478dc8794933781b478fae02aa44ed6b
 - name: haproxy
   version: 8.4.0
   url: https://github.com/cloudfoundry-incubator/haproxy-boshrelease/releases/download/v8.4.0/haproxy-8.4.0.tgz


### PR DESCRIPTION
* Add the ability to have additional manifest files applied - This will
allow CI to change to compiled versions

PKS needs this as we use the kubo.yml from the tile and we don't to be
fixed to compiled versions

[#152678378]

Signed-off-by: Brendan Nolan <bnolan@pivotal.io>