### PR TITLE
Change common_name for docker cert

### DIFF
--- a/manifests/kubo.yml
+++ b/manifests/kubo.yml
@@ -180,5 +180,4 @@ variables:
   type: certificate
   options:
     ca: kubo_ca
-    common_name: ((kubernetes_master_host))
-    alternative_names: [((kubernetes_master_host))]
+    common_name: docker.kubo.internal


### PR DESCRIPTION
I chose a random name that is not a real name for the worker VM.
But it is definitely not `kubernetes_master_host`.