### PR TITLE
Added namespaces to the cluster, creds and context in set_kubeconfig

### DIFF
--- a/bin/set_kubeconfig
+++ b/bin/set_kubeconfig
@@ -60,11 +60,13 @@ main() {
 
   address="https://${endpoint}:${port}"
   admin_password=$(bosh-cli int <(credhub get -n "${director_name}/${deployment_name}/kubo-admin-password" --output-json) --path=/value)
-  context_name="kubo-${deployment_name}"
+  cluster_name="kubo:${director_name}:${deployment_name}"
+  user_name="kubo:${director_name}:${deployment_name}-admin"
+  context_name="kubo:${director_name}:${deployment_name}"
 
-  kubectl config set-cluster "${deployment_name}" --server="$address" --certificate-authority="${tmp_ca_file}" --embed-certs=true
-  kubectl config set-credentials "${deployment_name}-admin" --token="${admin_password}"
-  kubectl config set-context "${context_name}" --cluster="${deployment_name}" --user="${deployment_name}-admin"
+  kubectl config set-cluster "${cluster_name}" --server="$address" --certificate-authority="${tmp_ca_file}" --embed-certs=true
+  kubectl config set-credentials "${user_name}" --token="${admin_password}"
+  kubectl config set-context "${context_name}" --cluster="${cluster_name}" --user="${user_name}"
   kubectl config use-context "${context_name}"
 
   echo "Created new kubectl context ${context_name}"


### PR DESCRIPTION
Without a namespace based on the bosh environment, clusters given the
same name will collide with one another and users must re-run
set_kubeconfig every time they wish to switch between a cluster. With
the namespaces, that should reduce the likelihood of a collision and
allow users to switch using `kubectl config use-context <context-name>`.

Issue #223.

[#152752429]