### PR TITLE
Removing unsupported organization key

### DIFF
--- a/manifests/kubo.yml
+++ b/manifests/kubo.yml
@@ -159,12 +159,10 @@ variables:
     ca: kubo_ca
     common_name: kubelet.kubo.internal
     alternative_names: []
-    organization: "system:nodes"
 - name: tls-kubernetes
   type: certificate
   options:
     ca: kubo_ca
-    organization: "system:masters"
     common_name: ((kubernetes_master_host))
     alternative_names:
     - ((kubernetes_master_host))


### PR DESCRIPTION
Organization section in variables is not a valid property for certificates. When using bosh cli to auto generate vars, it fails with the following error:

```
Getting all variables from variable definitions sections:
  Generating variable 'tls-kubelet':
    Failed to generate certificate, parameters are invalid:
      Unsupported certificate parameter 'organization'
```

Tested with bosh cli v2.0.45.

Seems like it only supports the following, (see [certificate_generator.go](https://github.com/cloudfoundry/bosh-cli/blob/master/vendor/github.com/cloudfoundry/config-server/types/certificate_generator.go#L35-L41)): 

```
var supportedCertParameters = []string{
	"common_name",
	"alternative_names",
	"is_ca",
	"ca",
	"extended_key_usage",
}
```