### PR TITLE
decouple deployment manifest from cloud-config with persistent_disk attribute

### DIFF
--- a/configurations/aws/cloud-config.yml
+++ b/configurations/aws/cloud-config.yml
@@ -25,12 +25,6 @@ vm_types:
     ephemeral_disk: {size: 100_000}
     iam_instance_profile: ((worker_iam_instance_profile))
 
-disk_types:
-- name: 10240
-  disk_size: 10240
-- name: 5120
-  disk_size: 5120
-
 networks:
 - name: ((deployments_network))
   type: manual

--- a/configurations/gcp/cloud-config.yml
+++ b/configurations/gcp/cloud-config.yml
@@ -42,12 +42,6 @@ vm_types:
     service_account: ((service_account_worker))
     tags: ((tags))
 
-disk_types:
-- name: 10240
-  disk_size: 10240
-- name: 5120
-  disk_size: 5120
-
 compilation:
   workers: 4
   network: *network_name

--- a/configurations/openstack/cloud-config.yml
+++ b/configurations/openstack/cloud-config.yml
@@ -19,12 +19,6 @@ vm_types:
     instance_type: m1.large
     root_disk_size_gb: 100
 
-disk_types:
-- name: 10240
-  disk_size: 10240
-- name: 5120
-  disk_size: 5120
-
 networks:
 - name: ((deployments_network))
   type: dynamic

--- a/configurations/vsphere/cloud-config.yml
+++ b/configurations/vsphere/cloud-config.yml
@@ -37,12 +37,6 @@ vm_types:
     cpu: 4
     disk: 102400
 
-disk_types:
-- name: 10240
-  disk_size: 10240
-- name: 5120
-  disk_size: 5120
-
 compilation:
   workers: 4
   network: *cloud_network

--- a/manifests/kubo.yml
+++ b/manifests/kubo.yml
@@ -82,7 +82,7 @@ instance_groups:
         delete_data_dir_on_stop: false
   stemcell: trusty
   vm_type: master
-  persistent_disk_type: 5120
+  persistent_disk: 5120
 
 - name: worker
   instances: ((worker_count))
@@ -127,7 +127,7 @@ instance_groups:
       api-token: ((kube-proxy-password))
   stemcell: trusty
   vm_type: worker
-  persistent_disk_type: 10240
+  persistent_disk: 10240
 
 update:
   canaries: 1


### PR DESCRIPTION
This PR is a piecemeal component of https://github.com/cloudfoundry-incubator/kubo-deployment/pull/237