### PR TITLE
Remove legacy BOSH CLI

### DIFF
--- a/docs/terraform/gcp/platform/kubo-infrastructure.tf
+++ b/docs/terraform/gcp/platform/kubo-infrastructure.tf
@@ -208,7 +208,6 @@ EOF
 
 apt-get update
 apt-get install -y build-essential zlibc zlib1g-dev ruby ruby-dev openssl libxslt-dev libxml2-dev libssl-dev libreadline6 libreadline6-dev libyaml-dev libsqlite3-dev sqlite3 jq git unzip
-gem install bosh_cli
 curl -o /tmp/cf.tgz https://s3.amazonaws.com/go-cli/releases/v6.20.0/cf-cli_6.20.0_linux_x86-64.tgz
 tar -zxvf /tmp/cf.tgz && mv cf /usr/bin/cf && chmod +x /usr/bin/cf
 


### PR DESCRIPTION
The “BOSH1” CLI was a rubygem, bosh_cli. “BOSH2” is a standalone Go binary.
When installed together, BOSH1’s path takes precedence over BOSH2. This
breaks deploy_bosh and deploy_k8s, which rely on BOSH2 features.

[#154432300]