### PR TITLE
Setup docker container log options

### DIFF
--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -137,6 +137,7 @@ instance_groups:
       iptables: false
       ip_masq: false
       log_level: error
+      log_options: [ "max-size=128m", "max-file=2" ]
       store_dir: /var/vcap/data
       storage_driver: overlay
       default_ulimits: [ "nofile=65536" ]


### PR DESCRIPTION
This should work according to:
https://github.com/cloudfoundry-incubator/docker-boshrelease/blob/master/jobs/docker/spec#L95
and https://docs.docker.com/engine/admin/logging/json-file/#usage

Essentially, we don't want to crash our servers because some long running container is spewing too much to the logs. We will cap size to 128m, and retain one old copy just for the sake of emergencies.  I think this makes sense as  a starter default.