### PR TITLE
Enhancements for AWS Disk encryption + Instance Profile Fix

### DIFF
--- a/bosh-deployment/aws/encrypt-disk.yml
+++ b/bosh-deployment/aws/encrypt-disk.yml
@@ -1,0 +1,8 @@
+---
+- type: replace
+  path: /cloud_provider/properties/aws/encrypted?
+  value: true
+
+- type: replace
+  path: /cloud_provider/properties/aws/kms_key_arn?
+  value: ((encrypt_key))

--- a/bosh-deployment/aws/iam-instance-profile.yml
+++ b/bosh-deployment/aws/iam-instance-profile.yml
@@ -18,3 +18,13 @@
 - type: replace
   path: /instance_groups/name=bosh/properties/aws/credentials_source?
   value: env_or_profile
+
+- type: remove
+  path: /cloud_provider/properties/aws/access_key_id
+
+- type: remove
+  path: /cloud_provider/properties/aws/secret_access_key
+
+- type: replace
+  path: /cloud_provider/properties/aws/credentials_source?
+  value: env_or_profile

--- a/configurations/aws/project-config.yml
+++ b/configurations/aws/project-config.yml
@@ -6,6 +6,7 @@ region: # AWS Region ID
 master_iam_instance_profile: # IAM Instance profile required by cloud provider on k8s master
 worker_iam_instance_profile: # IAM Instance profile required by cloud provider on k8s worker
 kubernetes_cluster_tag: # Tag to match public ELB subnet, Kubo workers subnet and Kubo worker VMs to make Kubernetes support ELB
+# encrypt_key: # ARN to be used for encryption, the KMS key.
 
 # IaaS routing mode settings
 # Comment out this section when using CF routing mode

--- a/configurations/aws/project-secrets.yml
+++ b/configurations/aws/project-secrets.yml
@@ -1,2 +1,3 @@
 access_key_id: # AWS Access Key ID
 secret_access_key: # AWS Access Key Secret
+# iam_instance_profile: # IAM Instance profile to be used rather than a key and secret


### PR DESCRIPTION
This PR contains additions to the AWS config template and property replacement within the BOSH manifest to enable AWS disk encryption.   In addition to these files, a documentation update will be needed to instruct users to add a reference to the aws/encrypt-disk.yml file within bin/deploy_bosh

Additionally, this PR contains a minor fix needed to enable instance profile to function properly.  access_key_id and secret_access_key must be removed from the main cloud provider properties in the manifest and a credentials_source specified.