### PR TITLE
Fix duplicate errand

### DIFF
--- a/manifests/ops-files/system-specs.yml
+++ b/manifests/ops-files/system-specs.yml
@@ -1,7 +1,7 @@
 - type: replace
   path: /instance_groups/-
   value:
-    name: apply-addons
+    name: apply-specs
     instances: 1
     networks:
     - name: default


### PR DESCRIPTION
Having the errand name as `apply-addons` and the errand job's name as `apply-specs` makes Bosh think there are two errands:
```
$> bosh -d kubo errands
Using deployment 'kubo'

Name
apply-addons
apply-specs

2 errands
```
This could be confusing for users. Changing the name to `apply-specs` resolves the duplication.