### PR TITLE
use vm_extensions for cloud provider keys and iaas load balancers

### DIFF
--- a/bin/generate_cloud_config
+++ b/bin/generate_cloud_config
@@ -18,12 +18,12 @@ ops_string_for_service_accounts() {
   local bosh_env=$1
   local ops_string=""
 
-  if ! bosh int "${bosh_env}/director.yml" --path='/service_account_master' &> /dev/null; then
-    ops_string="${ops_string} --ops-file=$(repo_directory)/manifests/ops-files/iaas/gcp/cloud-config/remove-service-account-master.yml"
+  if  bosh int "${bosh_env}/director.yml" --path='/service_account_master' &> /dev/null; then
+    ops_string="${ops_string} --ops-file=$(repo_directory)/manifests/ops-files/iaas/gcp/cloud-config/add-instance-service-account-master.yml"
   fi
 
-  if ! bosh int "${bosh_env}/director.yml" --path='/service_account_worker' &> /dev/null; then
-    ops_string="${ops_string} --ops-file=$(repo_directory)/manifests/ops-files/iaas/gcp/cloud-config/remove-service-account-worker.yml"
+  if  bosh int "${bosh_env}/director.yml" --path='/service_account_worker' &> /dev/null; then
+    ops_string="${ops_string} --ops-file=$(repo_directory)/manifests/ops-files/iaas/gcp/cloud-config/add-instance-service-account-worker.yml"
   fi
   echo "$ops_string"
 }

--- a/configurations/aws/cloud-config.yml
+++ b/configurations/aws/cloud-config.yml
@@ -9,21 +9,14 @@ azs:
   cloud_properties:
     availability_zone: ((az))
 
+vm_extensions:
+- name: cfcr-master-network-properties
+
 vm_types:
 - name: minimal
   cloud_properties:
     instance_type: t2.small
     ephemeral_disk: {size: 25_000}
-- name: master
-  cloud_properties:
-    instance_type: t2.small
-    ephemeral_disk: {size: 25_000}
-    iam_instance_profile: ((master_iam_instance_profile))
-- name: worker
-  cloud_properties:
-    instance_type: m4.xlarge
-    ephemeral_disk: {size: 100_000}
-    iam_instance_profile: ((worker_iam_instance_profile))
 
 networks:
 - name: default

--- a/configurations/gcp/cloud-config.yml
+++ b/configurations/gcp/cloud-config.yml
@@ -4,6 +4,9 @@ azs:
   cloud_properties:
     zone: ((zone))
 
+vm_extensions:
+- name: cfcr-master-network-properties
+
 networks:
 - name: default
   type: dynamic
@@ -24,22 +27,6 @@ vm_types:
     machine_type: n1-standard-1
     root_disk_size_gb: 20
     root_disk_type: pd-ssd
-    tags: ((tags))
-
-- name: master
-  cloud_properties:
-    machine_type: n1-standard-1
-    root_disk_size_gb: 20
-    root_disk_type: pd-ssd
-    service_account: ((service_account_master))
-    tags: ((tags))
-
-- name: worker
-  cloud_properties:
-    machine_type: n1-standard-2
-    root_disk_size_gb: 100
-    root_disk_type: pd-ssd
-    service_account: ((service_account_worker))
     tags: ((tags))
 
 compilation:

--- a/configurations/openstack/cloud-config.yml
+++ b/configurations/openstack/cloud-config.yml
@@ -3,21 +3,14 @@ azs:
   cloud_properties:
     availability_zone: ((az))
 
+vm_extensions:
+- name: cfcr-master-network-properties
+
 vm_types:
 - name: minimal
   cloud_properties:
     instance_type: m1.small
     root_disk_size_gb: 20
-
-- name: master
-  cloud_properties:
-    instance_type: m1.small
-    root_disk_size_gb: 20
-
-- name: worker
-  cloud_properties:
-    instance_type: m1.large
-    root_disk_size_gb: 100
 
 networks:
 - name: default

--- a/configurations/virtualbox/cloud-config.yml
+++ b/configurations/virtualbox/cloud-config.yml
@@ -3,6 +3,9 @@ azs:
 - name: z2
 - name: z3
 
+vm_extensions:
+- name: cfcr-master-network-properties
+
 vm_types:
 - name: default
 - name: small

--- a/configurations/vsphere/cloud-config.yml
+++ b/configurations/vsphere/cloud-config.yml
@@ -5,6 +5,9 @@ azs:
     datacenters:
     - clusters: [((vcenter_cluster)): { resource_pool: ((vcenter_rp))}]
 
+vm_extensions:
+- name: cfcr-master-network-properties
+
 networks:
 - name: default
   type: manual
@@ -24,18 +27,6 @@ vm_types:
     ram: 4096
     cpu: 1
     disk: 20480
-
-- name: master
-  cloud_properties:
-    ram: 4096
-    cpu: 1
-    disk: 20480
-
-- name: worker
-  cloud_properties:
-    ram: 8192
-    cpu: 4
-    disk: 102400
 
 compilation:
   workers: 4

--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -70,6 +70,8 @@ instance_groups:
   stemcell: trusty
   vm_type: minimal
 - name: master
+  vm_extensions:
+  - cfcr-master-network-properties
   instances: 3
   networks:
   - name: default

--- a/manifests/ops-files/iaas/aws/add-master-credentials.yml
+++ b/manifests/ops-files/iaas/aws/add-master-credentials.yml
@@ -1,3 +1,6 @@
+- type: remove
+  path: /instance_groups/name=master/vm_extensions/name=cfcr-worker-iam-properties?
+
 - type: replace
   path: /instance_groups/name=master/jobs/name=cloud-provider/properties/cloud-provider/aws?
   value:

--- a/manifests/ops-files/iaas/aws/add-worker-credentials.yml
+++ b/manifests/ops-files/iaas/aws/add-worker-credentials.yml
@@ -1,3 +1,6 @@
+- type: remove
+  path: /instance_groups/name=worker/vm_extensions/name=cfcr-worker-iam-properties?
+
 - type: replace
   path: /instance_groups/name=worker/jobs/name=cloud-provider/properties/cloud-provider/aws?
   value:

--- a/manifests/ops-files/iaas/aws/cloud-config/iam-instance-profiles.yml
+++ b/manifests/ops-files/iaas/aws/cloud-config/iam-instance-profiles.yml
@@ -1,0 +1,13 @@
+- type: replace
+  path: /vm_extensions/-
+  value:
+    name: cfcr-master-iam-properties
+    cloud_properties:
+      iam_instance_profile: ((master_iam_instance_profile))
+
+- type: replace
+  path: /vm_extensions/-
+  value:
+    name: cfcr-worker-iam-properties
+    cloud_properties:
+      iam_instance_profile: ((worker_iam_instance_profile))

--- a/manifests/ops-files/iaas/aws/cloud-config/lb.yml
+++ b/manifests/ops-files/iaas/aws/cloud-config/lb.yml
@@ -1,3 +1,5 @@
 - type: replace
-  path: /vm_types/name=master/cloud_properties/elbs?
-  value: [((master_target_pool))]
+  path: /vm_extensions/name=cfcr-master-network-properties?/cloud_properties
+  value:
+    elbs:
+    - ((master_target_pool))

--- a/manifests/ops-files/iaas/aws/cloud-provider.yml
+++ b/manifests/ops-files/iaas/aws/cloud-provider.yml
@@ -1,4 +1,12 @@
 - type: replace
+  path: /instance_groups/name=master/vm_extensions?/-
+  value: cfcr-master-iam-properties
+
+- type: replace
+  path: /instance_groups/name=worker/vm_extensions?/-
+  value: cfcr-worker-iam-properties
+
+- type: replace
   path: /instance_groups/name=master/jobs/-
   value:
     name: cloud-provider

--- a/manifests/ops-files/iaas/gcp/add-service-key-master.yml
+++ b/manifests/ops-files/iaas/gcp/add-service-key-master.yml
@@ -1,3 +1,6 @@
+- type: remove
+  path: /instance_groups/name=master/vm_extensions/name=cfcr-worker-iam-properties?
+
 - type: replace
   path: /instance_groups/name=master/jobs/name=cloud-provider/properties/cloud-provider/gce/service_key?
   value: ((service_key_master))

--- a/manifests/ops-files/iaas/gcp/add-service-key-worker.yml
+++ b/manifests/ops-files/iaas/gcp/add-service-key-worker.yml
@@ -1,3 +1,6 @@
+- type: remove
+  path: /instance_groups/name=worker/vm_extensions/name=cfcr-worker-iam-properties?
+
 - type: replace
   path: /instance_groups/name=worker/jobs/name=cloud-provider/properties/cloud-provider/gce/service_key?
   value: ((service_key_worker))

--- a/manifests/ops-files/iaas/gcp/cloud-config/add-instance-service-account-master.yml
+++ b/manifests/ops-files/iaas/gcp/cloud-config/add-instance-service-account-master.yml
@@ -1,0 +1,6 @@
+- type: replace
+  path: /vm_extensions/-
+  value:
+    name: cfcr-master-iam-properties
+    cloud_properties:
+      service_account: ((service_account_master))

--- a/manifests/ops-files/iaas/gcp/cloud-config/add-instance-service-account-worker.yml
+++ b/manifests/ops-files/iaas/gcp/cloud-config/add-instance-service-account-worker.yml
@@ -1,0 +1,6 @@
+- type: replace
+  path: /vm_extensions/-
+  value:
+    name: cfcr-worker-iam-properties
+    cloud_properties:
+      service_account: ((service_account_worker))

--- a/manifests/ops-files/iaas/gcp/cloud-config/load-balancer-target-pools.yml
+++ b/manifests/ops-files/iaas/gcp/cloud-config/load-balancer-target-pools.yml
@@ -1,3 +1,7 @@
 - type: replace
-  path: /vm_types/name=master/cloud_properties/target_pool?
-  value: ((master_target_pool))
+  path: /vm_extensions/name=cfcr-master-cloud-properties?/cloud_properties/target_pool
+  value: ((cfcr_master_target_pool))
+
+- type: replace
+  path: /vm_extensions/name=cfcr-master-cloud-properties?/cloud_properties/tags/-
+  value: ((cfcr_master_target_pool))

--- a/manifests/ops-files/iaas/gcp/cloud-config/remove-service-account-master.yml
+++ b/manifests/ops-files/iaas/gcp/cloud-config/remove-service-account-master.yml
@@ -1,2 +1,0 @@
-- type: remove
-  path: /vm_types/name=master/cloud_properties/service_account

--- a/manifests/ops-files/iaas/gcp/cloud-config/remove-service-account-worker.yml
+++ b/manifests/ops-files/iaas/gcp/cloud-config/remove-service-account-worker.yml
@@ -1,2 +1,0 @@
-- type: remove
-  path: /vm_types/name=worker/cloud_properties/service_account

--- a/manifests/ops-files/iaas/gcp/cloud-provider.yml
+++ b/manifests/ops-files/iaas/gcp/cloud-provider.yml
@@ -1,4 +1,12 @@
 - type: replace
+  path: /instance_groups/name=master/vm_extensions?/-
+  value: cfcr-master-iam-properties
+
+- type: replace
+  path: /instance_groups/name=worker/vm_extensions?/-
+  value: cfcr-worker-iam-properties
+
+- type: replace
   path: /instance_groups/name=master/jobs/-
   value:
     name: cloud-provider

--- a/src/kubo-deployment-tests/generate_cloud_config_test.go
+++ b/src/kubo-deployment-tests/generate_cloud_config_test.go
@@ -38,13 +38,13 @@ var _ = Describe("Generate cloud config", func() {
 	It("Does not include load balancer config for cf-based environment", func() {
 		bash.Run("main", []string{filepath.Join(testEnvironmentPath, "test_vsphere")})
 
-		Expect(stdout).NotTo(gbytes.Say("    target_pool: \\(\\(master_target_pool\\)\\)"))
+		Expect(stdout).NotTo(gbytes.Say("    target_pool: \\(\\(cfcr_master_target_pool\\)\\)"))
 	})
 
 	It("includes load balancer configuration for iaas-based environment", func() {
 		bash.Run("main", []string{kuboEnv})
 
-		Expect(stdout).To(gbytes.Say("    target_pool: \\(\\(master_target_pool\\)\\)"))
+		Expect(stdout).To(gbytes.Say("    target_pool: \\(\\(cfcr_master_target_pool\\)\\)"))
 	})
 
 	It("fails with no arguments", func() {
@@ -109,11 +109,11 @@ var _ = Describe("Generate cloud config", func() {
 					command.Dir = pathToScript("")
 					Expect(command.Run()).To(Succeed())
 
-					masterServiceAccount, err := propertyFromYaml("/vm_types/name=master/cloud_properties/service_account", stdout.Contents())
+					masterServiceAccount, err := propertyFromYaml("/vm_extensions/name=cfcr-master-iam-properties/cloud_properties/service_account", stdout.Contents())
 					Expect(err).ToNot(HaveOccurred())
 					Expect(masterServiceAccount).To(Equal("master-service-account@google.com"))
 
-					workerServiceAccount, err := propertyFromYaml("/vm_types/name=worker/cloud_properties/service_account", stdout.Contents())
+					workerServiceAccount, err := propertyFromYaml("/vm_extensions/name=cfcr-worker-iam-properties/cloud_properties/service_account", stdout.Contents())
 					Expect(err).ToNot(HaveOccurred())
 					Expect(workerServiceAccount).To(Equal("worker-service-account@google.com"))
 				})
@@ -143,11 +143,11 @@ var _ = Describe("Generate cloud config", func() {
 					command.Dir = pathToScript("")
 					Expect(command.Run()).To(Succeed())
 
-					masterServiceAccount, err := propertyFromYaml("/vm_types/name=master/cloud_properties/service_account", stdout.Contents())
+					masterServiceAccount, err := propertyFromYaml("/vm_extensions/name=cfcr-master-iam-properties/cloud_properties/service_account", stdout.Contents())
 					Expect(err).ToNot(HaveOccurred())
 					Expect(masterServiceAccount).To(Equal("master-service-account@google.com"))
 
-					workerServiceAccount, err := propertyFromYaml("/vm_types/name=worker/cloud_properties/service_account", stdout.Contents())
+					workerServiceAccount, err := propertyFromYaml("/vm_extensions/name=cfcr-worker-iam-properties/cloud_properties/service_account", stdout.Contents())
 					Expect(err).ToNot(HaveOccurred())
 					Expect(workerServiceAccount).To(Equal("worker-service-account@google.com"))
 				})

--- a/src/kubo-deployment-tests/resources/ops-files/cloud-config-plus-plus.yml
+++ b/src/kubo-deployment-tests/resources/ops-files/cloud-config-plus-plus.yml
@@ -1,3 +1,3 @@
 - type: replace
-  path: /vm_types/name=worker/cloud_properties/tags
+  path: /vm_types/name=worker?/cloud_properties/tags
   value: supertest

--- a/src/kubo-deployment-tests/resources/ops-files/cloud-config-plus.yml
+++ b/src/kubo-deployment-tests/resources/ops-files/cloud-config-plus.yml
@@ -1,3 +1,3 @@
 - type: replace
-  path: /vm_types/name=worker/cloud_properties/machine_type
+  path: /vm_types/name=worker?/cloud_properties/machine_type
   value: foo


### PR DESCRIPTION
Hey cfcrians! I've been poking around in kubo-deployment for a while now and thinking about how we might be able to better use bosh across IAASes and heterogenous deployment strategies. One thing that's been a fantastic operator configuration point for [cf-deployment](https://github.com/cloudfoundry/cf-deployment) is clever use of vm_extensions configured by operators in their cloud-configs. Some details about that can be found in [On Cloud Configs](https://github.com/cloudfoundry/cf-deployment/blob/master/texts/on-cloud-configs.md).

By using vm_extensions, Operators can vertically scale `cf-deployment` instances using vm_type, whilst keeping their iaas provisioned load balancer configurations, ephemeral disks, and instance iam profiles in separate vm extensions, and this PR aims to bring that same flexibility to kubo-deployment.

In brief:
* canonical vm_extension names provide a consistent interface for operators to configure their cpis for cfcr support.
* defining a vm extension named cfcr-master-network-properties gives bosh operators a place to hook up iaas-specific lb config. 
* cloud-provider ops files can, independently of vm_type, add their own cfcr-{master,worker}-iam-properties to attach iaas+instance-specific privileges.

Many of the details of this change definitely welcome discussion. One thing I flip-flopped on is whether `cfcr-master-network-properties` should be required in a cloud config or not. given that static ips are used on iaases without load balancers and that there are ways to route to kubeapis via the cf routing layer. I ended up making it required as beginner operators on public clouds might find it a bit surprising that the base manifest doesn't deploy with consistently routable kube-apiserver.

Best,
Connor