### PR TITLE
add cloud-config opsfile for vsphere static ips

### DIFF
--- a/manifests/README.md
+++ b/manifests/README.md
@@ -220,6 +220,8 @@ kubectl get all
 | **vSphere** | | |
 | [`ops-files/iaas/vsphere/cloud-provider.yml`](ops-files/iaas/vsphere/cloud-provider.yml) | Enable Cloud Provider for vSphere | - |
 | [`ops-files/iaas/vsphere/set-working-dir-no-rp.yml`](ops-files/iaas/vsphere/set-working-dir-no-rp.yml) | Configure vSphere cloud provider's working dir if there is no resource pool | - |
+| [`ops-files/iaas/vsphere/master-static-ip.yml`](ops-files/iaas/vsphere/master-static-ip.yml) | Attach static IPs from the default network to the kubernetes master node(s) | - |
+| [`ops-files/iaas/vsphere/cloud-config/add-static-ips.yml`](ops-files/iaas/vsphere/cloud-config/add-static-ips.yml) | Configure cloud-configs's default network to reserve static ip(s) | - |
 
 
 ### Proxy

--- a/manifests/ops-files/iaas/vsphere/cloud-config/add-static-ips.yml
+++ b/manifests/ops-files/iaas/vsphere/cloud-config/add-static-ips.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /networks/name=default/subnets/0/static?
+  value: [ ((kubernetes_master_host)) ]


### PR DESCRIPTION
It took me a hot minute to figure out why I couldn't get vsphere to deploy with https://github.com/cloudfoundry-incubator/kubo-deployment/blob/master/manifests/ops-files/iaas/vsphere/master-static-ip.yml , but it turns out that you need as many static IPs in your cloud-config as you have in your instances in your deployment. I made an ops file to do this for the bbl plan patch I'm preparing, but I think this ops file is one that pretty much any raw vsphere operator is going to need, regardless of whether they use bbl or not. 