### PR TITLE
Adds 'storage.objectViewer' role for master and worker service accounts

### DIFF
--- a/docs/terraform/gcp/platform/kubo-infrastructure.tf
+++ b/docs/terraform/gcp/platform/kubo-infrastructure.tf
@@ -107,6 +107,14 @@ data "google_iam_policy" "admin" {
       "serviceAccount:${google_service_account.worker.email}",
     ]
   }
+
+  binding {
+    role = "roles/storage.objectViewer"
+
+    members = [
+      "serviceAccount:${google_service_account.worker.email}",
+    ]
+  }
 }
 
 resource "google_compute_route" "nat-primary" {


### PR DESCRIPTION
* This is required in order to pull images from your project's container
registry

Signed-off-by: Brenda Chan <brchan@pivotal.io>