### PR TITLE
remove node_security_group_id variable

### DIFF
--- a/docs/terraform/aws/routing/kubo-lbs.tf
+++ b/docs/terraform/aws/routing/kubo-lbs.tf
@@ -6,10 +6,6 @@ variable "vpc_id" {
     type = "string"
 }
 
-variable "node_security_group_id" {
-    type = "string"
-}
-
 variable "public_subnet_id" {
     type = "string"
 }


### PR DESCRIPTION
Should also be removed from documentation on this page: https://docs-cfcr.cfapps.io/installing/aws/routing-aws/