### PR TITLE
Update manifests and ops-files for flexible admission plugins

### DIFF
--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -89,17 +89,27 @@ instance_groups:
   - name: kube-apiserver
     release: kubo
     properties:
-      admin-username: admin
       admin-password: ((kubo-admin-password))
-      kubelet-password: ((kubelet-password))
-      kube-proxy-password: ((kube-proxy-password))
-      kube-controller-manager-password: ((kube-controller-manager-password))
-      kube-scheduler-password: ((kube-scheduler-password))
-      route-sync-password: ((route-sync-password))
-      kubelet-drain-password: ((kubelet-drain-password))
-      backend_port: 8443 # Bosh links hack
-      port: 8443
+      admin-username: admin
+      admission-plugins:
+        DefaultStorageClass: true
+        DenyEscalatingExec: true
+        LimitRanger: true
+        MutatingAdmissionWebhook: true
+        NamespaceExists: true
+        NamespaceLifecycle: true
+        ResourceQuota: true
+        SecurityContextDeny: true
+        ServiceAccount: true
       authorization-mode: rbac
+      backend_port: 8443 # Bosh links hack
+      kube-controller-manager-password: ((kube-controller-manager-password))
+      kube-proxy-password: ((kube-proxy-password))
+      kube-scheduler-password: ((kube-scheduler-password))
+      kubelet-drain-password: ((kubelet-drain-password))
+      kubelet-password: ((kubelet-password))
+      port: 8443
+      route-sync-password: ((route-sync-password))
       service-account-public-key: ((service-account-key.public_key))
       tls:
         kubernetes:

--- a/manifests/ops-files/allow-privileged-containers.yml
+++ b/manifests/ops-files/allow-privileged-containers.yml
@@ -1,4 +1,7 @@
 ---
+- type: remove
+  path: /instance_groups/name=master/jobs/name=kube-apiserver/properties/admission-plugins/SecurityContextDeny
+
 - type: replace
   path: /instance_groups/name=master/jobs/name=kube-apiserver/properties/allow_privileged?
   value: true

--- a/manifests/ops-files/disable-deny-escalating-exec.yml
+++ b/manifests/ops-files/disable-deny-escalating-exec.yml
@@ -1,4 +1,3 @@
 ---
-- type: replace
-  path: /instance_groups/name=master/jobs/name=kube-apiserver/properties/deny_escalating_exec?
-  value: false
+- type: remove
+  path: /instance_groups/name=master/jobs/name=kube-apiserver/properties/admission-plugins/DenyEscalatingExec


### PR DESCRIPTION
**What this PR does / why we need it**:
This updates the manifest and ops-files to support https://github.com/cloudfoundry-incubator/kubo-release/pull/206. This makes it so that the operator can explicitly control the enabled and disabled admission plugins on `kube-apiserver`. The manifest now defaults to the behavior that was previously hardwired in `kubo-release`.

**How can this PR be verified?**
Manual inspection to ensure that the admission plugins here are the same as those hardwired in `kubo-release` prior to https://github.com/cloudfoundry-incubator/kubo-release/pull/206.

**Is there any change in kubo-release?**
https://github.com/cloudfoundry-incubator/kubo-release/pull/206

**Is there any change in kubo-ci?**
No.

**Does this affect upgrade, or is there any migration required?**
No.

**Which issue(s) this PR fixes:**
https://github.com/cloudfoundry-incubator/kubo-deployment/issues/309
[#157758561](https://www.pivotaltracker.com/story/show/157758561)

**Release note**:

```release-note
Kubernetes Admission Control Plugins are now globally available to the BOSH operator.

The manifest will now explicitly consume a map of the format `<name>: <boolean>`. 
For example:

    ```
    jobs:
      - name: kube-apiserver
        release: kubo
        properties:
          ...
          admission-plugins:
            DefaultStorageClass: true
            DenyEscalatingExec: true
            LimitRanger: true
            MutatingAdmissionWebhook: true
            NamespaceExists: true
            NamespaceLifecycle: true
            ResourceQuota: true
            SecurityContextDeny: true
            ServiceAccount: true
          ...
    ```

```
