### PR TITLE
Add metrics-server creds

### DIFF
--- a/bin/test-standard-ops.sh
+++ b/bin/test-standard-ops.sh
@@ -47,6 +47,7 @@ test_standard_ops() {
       check_interpolation "disable-anonymous-auth.yml"
       check_interpolation "disable-deny-escalating-exec.yml"
       check_interpolation "add-oidc-endpoint.yml" "-l example-vars-files/misc/oidc.yml"
+      check_interpolation "delete-heapster.yml"
 
       # Dev
       check_interpolation "kubo-local-release.yml"

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -237,6 +237,7 @@ kubectl get all
 | [`ops-files/disable-anonymous-auth.yml`](ops-files/disable-anonymous-auth.yml) | Disable `anonymous-auth` on the API server | - |
 | [`ops-files/disable-deny-escalating-exec.yml`](ops-files/disable-deny-escalating-exec.yml) | Disable `DenyEscalatingExec` in API server admission control | - |
 | [`ops-files/add-oidc-endpoint.yml`](ops-files/add-oidc-endpoint.yml) | Enable OIDC authentication for the Kubernetes cluster | - |
+| [`ops-files/delete-heapster.yml`](ops-files/delete-heapster.yml) | Deploy Heapster and Influxdb. Heapster is in the process of being deprecated and this will become a default ops once done. | - |
 
 ### Dev
 

--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -67,8 +67,7 @@ instance_groups:
       admin-password: ((kubo-admin-password))
       tls:
         kubernetes: ((tls-kubernetes))
-        heapster: ((tls-heapster))
-        influxdb: ((tls-influxdb))
+        metrics: ((tls-metrics))
         kubernetes-dashboard: ((tls-kubernetes-dashboard))
   stemcell: trusty
   vm_type: minimal
@@ -270,20 +269,14 @@ variables:
     extended_key_usage:
     - client_auth
 
-- name: tls-heapster
+- name: tls-metrics
   type: certificate
   options:
     ca: kubo_ca
-    common_name: heapster
+    common_name: metrics-service.kube-system.svc
     alternative_names:
-    - "heapster.kube-system.svc.cluster.local"
-
-- name: tls-influxdb
-  type: certificate
-  options:
-    ca: kubo_ca
-    common_name: monitoring-influxdb
-    alternative_names: []
+    - "metrics-server.kube-system.svc"
+    - "localhost"
 
 - name: kubernetes-dashboard-ca
   type: certificate

--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -67,6 +67,8 @@ instance_groups:
       admin-password: ((kubo-admin-password))
       tls:
         kubernetes: ((tls-kubernetes))
+        heapster: ((tls-heapster))
+        influxdb: ((tls-influxdb))
         metrics: ((tls-metrics))
         kubernetes-dashboard: ((tls-kubernetes-dashboard))
   stemcell: trusty
@@ -268,6 +270,21 @@ variables:
     common_name: etcdClient
     extended_key_usage:
     - client_auth
+
+- name: tls-heapster
+  type: certificate
+  options:
+    ca: kubo_ca
+    common_name: heapster
+    alternative_names:
+    - "heapster.kube-system.svc.cluster.local"
+
+- name: tls-influxdb
+  type: certificate
+  options:
+    ca: kubo_ca
+    common_name: monitoring-influxdb
+    alternative_names: []
 
 - name: tls-metrics
   type: certificate

--- a/manifests/ops-files/delete-heapster.yml
+++ b/manifests/ops-files/delete-heapster.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /instance_groups/name=apply-addons/jobs/name=apply-specs/properties/delete-heapster?
+  value: true


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the creds necessary for the `metrics-server` and also adds an ops-file that can
control whether to delete Heapster and Influxdb.

**How can this PR be verified?**
There are spec tests on the [related kubo-release PR](https://github.com/cloudfoundry-incubator/kubo-release/pull/211).
[Horizontal Pod Autoscaler Walkthrough](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/) provides a step-by-step example of the HPA in action.

**Is there any change in kubo-release?**
https://github.com/cloudfoundry-incubator/kubo-release/pull/211

**Is there any change in kubo-ci?**
None.

**Does this affect upgrade, or is there any migration required?**
Not unless the operator specifies `delete-heapster: true`, then those services will be deleted and
Dashboard will not properly serve the pod metrics.

**Which issue(s) this PR fixes:**
[#157915809](https://www.pivotaltracker.com/story/show/157915809)

**Release note**:

```release-note
Enabled the `metrics-server` and registered it as an API for `metrics.k8s.io/v1beta1`. 
This, in turn, enables certain metrics-based features like the Horizontal Pod Autoscaler
and a better integration with features like `kubectl top`.
```