### PR TITLE
Persistent disk is not used for kubelet

### DIFF
--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -193,7 +193,6 @@ instance_groups:
       api-token: ((kube-proxy-password))
   stemcell: trusty
   vm_type: small-highmem
-  persistent_disk: 10240
 
 update:
   canaries: 1


### PR DESCRIPTION
I think it has been used for glusterfs experiment long time ago.