### PR TITLE
Remove DNS API variables if runtime config is used

### DIFF
--- a/bosh-deployment/runtime-configs/dns.yml
+++ b/bosh-deployment/runtime-configs/dns.yml
@@ -1,8 +1,8 @@
 releases:
-- name: bosh-dns
-  version: 0.2.0
-  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-release?v=0.2.0
-  sha1: 9231b7c7d2f6aa85e0cb77fdeef7add54fdb3f1a
+- name: "bosh-dns"
+  version: "1.6.0"
+  url: "https://bosh.io/d/github.com/cloudfoundry/bosh-dns-release?v=1.6.0"
+  sha1: "bb7f1cf29c4186fdba4a049fb6feb5638227d9a4"
 
 addons:
 - name: bosh-dns
@@ -18,6 +18,11 @@ addons:
           tls: ((/dns_healthcheck_server_tls))
         client:
           tls: ((/dns_healthcheck_client_tls))
+      api:
+        server:
+          tls: ((/dns_api_server_tls))
+        client:
+          tls: ((/dns_api_client_tls))
   include:
     stemcell:
     - os: ubuntu-trusty
@@ -34,9 +39,15 @@ addons:
           tls: ((/dns_healthcheck_server_tls))
         client:
           tls: ((/dns_healthcheck_client_tls))
+      api:
+        server:
+          tls: ((/dns_api_server_tls))
+        client:
+          tls: ((/dns_api_client_tls))
   include:
     stemcell:
     - os: windows2012R2
+    - os: windows2016
 
 variables:
 - name: /dns_healthcheck_tls_ca
@@ -58,5 +69,27 @@ variables:
   options:
     ca: /dns_healthcheck_tls_ca
     common_name: health.bosh-dns
+    extended_key_usage:
+    - client_auth
+
+- name: /dns_api_tls_ca
+  type: certificate
+  options:
+    is_ca: true
+    common_name: dns-api-tls-ca
+
+- name: /dns_api_server_tls
+  type: certificate
+  options:
+    ca: /dns_api_tls_ca
+    common_name: api.bosh-dns
+    extended_key_usage:
+    - server_auth
+
+- name: /dns_api_client_tls
+  type: certificate
+  options:
+    ca: /dns_api_tls_ca
+    common_name: api.bosh-dns
     extended_key_usage:
     - client_auth

--- a/manifests/ops-files/use-runtime-config-bosh-dns.yml
+++ b/manifests/ops-files/use-runtime-config-bosh-dns.yml
@@ -13,3 +13,12 @@
 
 - type: remove
   path: /variables/opsname=global_dns_healthcheck_client_tls
+
+- type: remove
+  path: /variables/opsname=global_dns_api_server_tls
+  
+- type: remove
+  path: /variables/opsname=global_dns_api_client_tls
+  
+- type: remove
+  path: /variables/opsname=global_dns_api_tls_ca


### PR DESCRIPTION
**What this PR does / why we need it**:
If the end user uses runtime config with latest bosh dns.

**How can this PR be verified?**
Apply following runtime config to the bosh director
https://github.com/cloudfoundry/bosh-deployment/blob/master/runtime-configs/dns.yml

Deploy CFCR with manifests/ops-files/use-runtime-config-bosh-dns.yml

**Release note**:
```release-note
CFCR can be deployed with latest Bosh DNS runtime config
```
