### PR TITLE
Add syslog forwarder

### DIFF
--- a/bin/test-standard-ops.sh
+++ b/bin/test-standard-ops.sh
@@ -48,7 +48,7 @@ test_standard_ops() {
       check_interpolation "add-proxy.yml" "-v http_proxy=10.10.10.10:8000 -v https_proxy=10.10.10.10:8000 -v no_proxy=localhost,127.0.0.1"
 
       # Syslog
-      check_interpolation "add-syslog.yml" "add-syslog.yml" "-l example-vars-files/add-syslog.yml"  
+      check_interpolation "add-syslog.yml" "-l example-vars-files/add-syslog.yml"  
       check_interpolation "name:add-syslog-tls.yml" "add-syslog.yml" "-o add-syslog-tls.yml" "-l example-vars-files/add-syslog.yml" "-l example-vars-files/add-syslog-tls.yml"
 
       # Kubernetes

--- a/bin/test-standard-ops.sh
+++ b/bin/test-standard-ops.sh
@@ -47,6 +47,9 @@ test_standard_ops() {
       # HTTP proxy options
       check_interpolation "add-proxy.yml" "-v http_proxy=10.10.10.10:8000 -v https_proxy=10.10.10.10:8000 -v no_proxy=localhost,127.0.0.1"
 
+      # Syslog
+      check_interpolation "add-syslog.yml" "add-syslog-tls.yml" "-l example-vars-files/add-syslog.yml" "-l example-vars-files/add-syslog-tls.yml"  
+
       # Kubernetes
       check_interpolation "addons-spec.yml" "-v addons-spec={}"
       check_interpolation "allow-privileged-containers.yml"

--- a/bin/test-standard-ops.sh
+++ b/bin/test-standard-ops.sh
@@ -48,7 +48,8 @@ test_standard_ops() {
       check_interpolation "add-proxy.yml" "-v http_proxy=10.10.10.10:8000 -v https_proxy=10.10.10.10:8000 -v no_proxy=localhost,127.0.0.1"
 
       # Syslog
-      check_interpolation "add-syslog.yml" "add-syslog-tls.yml" "-l example-vars-files/add-syslog.yml" "-l example-vars-files/add-syslog-tls.yml"  
+      check_interpolation "add-syslog.yml" "add-syslog.yml" "-l example-vars-files/add-syslog.yml"  
+      check_interpolation "name:add-syslog-tls.yml" "add-syslog.yml" "-o add-syslog-tls.yml" "-l example-vars-files/add-syslog.yml" "-l example-vars-files/add-syslog-tls.yml"
 
       # Kubernetes
       check_interpolation "addons-spec.yml" "-v addons-spec={}"

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -160,6 +160,14 @@ svc/kubernetes   ClusterIP   10.100.200.1   <none>        443/TCP   2h
 |:--- |:--- |:--- |
 | [`ops-files/enable-bbr.yml`](ops-files/enable-bbr.yml) | Deploy jobs required to enable BBR. | Only tested with single master. |
 
+### Syslog
+
+| Name | Purpose | Notes |
+|:---  |:---     |:---   |
+| [`ops-files/add-syslog.yml`](ops-files/add-syslog.yml) | Enables forwarding local syslog events in RFC5424 format to a remote syslog endpoint.  |
+| [`ops-files/add-syslog-tls.yml`](ops-files/add-syslog-tls.yml) | Requires `add-syslog.yml`. Configure TLS for syslog fowarding. |
+
+
 ### Dev
 
 | Name | Purpose | Notes |

--- a/manifests/ops-files/add-syslog-tls.yml
+++ b/manifests/ops-files/add-syslog-tls.yml
@@ -1,0 +1,12 @@
+# requires add-syslog.yml
+- type: replace
+  path: /addons/name=syslog_forwarder/jobs/name=syslog_forwarder/properties/syslog/tls_enabled?
+  value: true
+
+- type: replace
+  path: /addons/name=syslog_forwarder/jobs/name=syslog_forwarder/properties/syslog/permitted_peer?
+  value: ((syslog_permitted_peer))
+
+- type: replace
+  path: /addons/name=syslog_forwarder/jobs/name=syslog_forwarder/properties/syslog/ca_cert?
+  value: ((syslog_ca_cert))

--- a/manifests/ops-files/add-syslog.yml
+++ b/manifests/ops-files/add-syslog.yml
@@ -1,0 +1,21 @@
+- type: replace
+  path: /addons?/-
+  value:
+    name: syslog_forwarder
+    jobs:
+    - name: syslog_forwarder
+      release: syslog
+      properties:
+        syslog:
+          address: ((syslog_address))
+          port: ((syslog_port))
+          transport: ((syslog_transport))
+          forward_files: true
+
+- type: replace
+  path: /releases/-
+  value:
+    name: syslog
+    version: "11.3.2"
+    url: "https://bosh.io/d/github.com/cloudfoundry/syslog-release?v=11.3.2"
+    sha1: "64cf40d44746b50edffa78cb0e0dd6f072fee695"

--- a/manifests/ops-files/example-vars-files/add-syslog-tls.yml
+++ b/manifests/ops-files/example-vars-files/add-syslog-tls.yml
@@ -1,0 +1,12 @@
+syslog_permitted_peer: "*.example.com"
+syslog_ca_cert: |
+  -----BEGIN CERTIFICATE-----
+  MIIFdDCCBFygAwIBAgIQJ2buVutJ846r13Ci/ITeIjANBgkqhkiG9w0BAQwFADBv
+  ...
+  pu/xO28QOG8=
+  -----END CERTIFICATE-----
+  -----BEGIN CERTIFICATE-----
+  MIIENjCCAx6gAwIBAgIBATANBgkqhkiG9w0BAQUFADBvMQswCQYDVQQGEwJTRTEU
+  ...
+  mnkPIAou1Z5jJh5VkpTYghdae9C8x49OhgQ=
+  -----END CERTIFICATE-----

--- a/manifests/ops-files/example-vars-files/add-syslog.yml
+++ b/manifests/ops-files/example-vars-files/add-syslog.yml
@@ -1,0 +1,3 @@
+syslog_address: logs.example.com
+syslog_port: 514
+syslog_transport: tcp


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--
Why is this PR important? What is the user impact?
-->
This PR adds ops-file to enable syslog forwarding with [syslog-release](https://github.com/cloudfoundry/syslog-release).

**How can this PR be verified?**

Configure a syslog endpoint in `add-syslog.yml` and `add-syslog-tls.yml` (if TLS is required) and check whether component logs (such as kube-apiserver) are received in the syslog server.

**Is there any change in kubo-release?**

No

**Is there any change in kubo-ci?**

No

**Does this affect upgrade, or is there any migration required?**

No

**Which issue(s) this PR fixes:**

Forwarding component logs to a syslog endpoint

**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
Added ops-files to forward component logs to a syslog endpoint.
```
