### PR TITLE
Add ops-file to change etcd's metrics url

### DIFF
--- a/bin/test-standard-ops.sh
+++ b/bin/test-standard-ops.sh
@@ -62,6 +62,9 @@ test_standard_ops() {
       check_interpolation "add-hostname-to-master-certificate.yml" "-v api-hostname=example.com"
       check_interpolation "use-coredns.yml"
 
+      # Etcd
+      check_interpolation "change-etcd-metrics-url.yml" "-v etcd_metrics_protocol=http -v etcd_metrics_port=2378"
+
       # BBR
       check_interpolation "enable-bbr.yml"
 

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -87,6 +87,13 @@ For deeper documentation to deploy CFCR go [here](https://github.com/cloudfoundr
 | [`ops-files/add-hostname-to-master-certificate.yml`](ops-files/add-hostname-to-master-certificate.yml) | Add hostname to master certificate | Extra Vars Required:<br>- **api-hostname:** Required for TLS certificate of apiserver |
 | [`ops-files/use-coredns.yml`](ops-files/use-coredns.yml) | Add CoreDNS to the list of addons deployed by the apply-specs errand | - |
 
+### Etcd
+
+| Name | Purpose | Notes|
+|:--- |:--- |:--- |
+| [`ops-files/change-etcd-metrics-url.yml`](ops-files/change-etcd-metrics-url.yml) | Change procotol and port of the etcd's metrics endpoint | - |
+
+
 ### BOSH Backup & Restore
 
 | Name | Purpose | Notes|

--- a/manifests/ops-files/change-etcd-metrics-url.yml
+++ b/manifests/ops-files/change-etcd-metrics-url.yml
@@ -1,0 +1,8 @@
+---
+- type: replace
+  path: /instance_groups/name=master/jobs/name=etcd/properties/etcd?/metrics_protocol?
+  value: ((etcd_metrics_protocol))
+
+- type: replace
+  path: /instance_groups/name=master/jobs/name=etcd/properties/etcd?/metrics_port?
+  value: ((etcd_metrics_port))


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--
Why is this PR important? What is the user impact?
-->

This PR add an ops file to change etcd's metrics url so that operator can use a separate port and protocol for the metrics endpoint.

**How can this PR be verified?**
run `./bin/run_tests`

**Is there any change in kubo-release?**
no

**Is there any change in kubo-ci?**
no

**Does this affect upgrade, or is there any migration required?**
no

**Which issue(s) this PR fixes:**

related to https://github.com/cloudfoundry-incubator/cfcr-etcd-release/pull/9

**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
Added ops-files to change the protocol and port of the metrics endpoint of etcd.
```
