### PR TITLE
Fix addons block

### DIFF
--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -1,6 +1,6 @@
 addons:
 - include:
-    stemcells:
+    stemcell:
     - os: ubuntu-trusty
     - os: ubuntu-xenial
   jobs:


### PR DESCRIPTION
https://bosh.io/docs/runtime-config/#placement-rules

Signed-off-by: Leah Hanson <lhanson@pivotal.io>

**What this PR does / why we need it**:
The addons block was adding those addons to every stemcell type, not only xenial/trusty ones.

**How can this PR be verified?**
Spin up a Windows node, see that it tries to place addon jobs onto that VM.

**Is there any change in kubo-release?**
Nope
**Is there any change in kubo-ci?**
Nope
**Does this affect upgrade, or is there any migration required?**
Nope
**Which issue(s) this PR fixes:**
None filed
**Release note**:
```release-note
Fixed addons block in cfcr.yml to properly exclude non-Xenial/Trusty stemcells from addon jobs.
```
