### PR TITLE
Support configurable cloud-config

### DIFF
--- a/manifests/ops-files/iaas/azure/cloud-provider.yml
+++ b/manifests/ops-files/iaas/azure/cloud-provider.yml
@@ -6,20 +6,21 @@
     properties:
       cloud-provider:
         type: azure
-        azure:
+      cloud-config:
+        Global:
+          aadClientId: ((client_id))
+          aadClientSecret: ((client_secret))
           cloud: ((azure_cloud_name))
-          subscription-id: ((subscription_id))
-          tenant-id: ((tenant_id))
-          service-principal-id: ((client_id))
-          service-principal-secret: ((client_secret))
           location: ((location))
-          resource-group-name: ((resource_group_name))
-          vnet-resource-group-name: ((vnet_resource_group_name))
-          vnet-name: ((vnet_name))
-          subnet-name: ((subnet_name))
-          network-security-group-name: ((default_security_group))
-          availability-set: ((primary_availability_set))
-
+          primaryAvailabilitySetName: ((primary_availability_set))
+          resourceGroup: ((resource_group_name))
+          securityGroupName: ((default_security_group))
+          subnetName: ((subnet_name))
+          subscriptionId: ((subscription_id))
+          tenantId: ((tenant_id))
+          useInstanceMetadata: true
+          vnetName: ((vnet_name))
+          vnetResourceGroup: ((vnet_resource_group_name))
     provides:
       cloud-provider: {as: master-cloud-provider}
 
@@ -51,19 +52,21 @@
     properties:
       cloud-provider:
         type: azure
-        azure:
+      cloud-config:
+        Global:
+          aadClientId: ((client_id))
+          aadClientSecret: ((client_secret))
           cloud: ((azure_cloud_name))
-          subscription-id: ((subscription_id))
-          tenant-id: ((tenant_id))
-          service-principal-id: ((client_id))
-          service-principal-secret: ((client_secret))
           location: ((location))
-          resource-group-name: ((resource_group_name))
-          vnet-resource-group-name: ((vnet_resource_group_name))
-          vnet-name: ((vnet_name))
-          subnet-name: ((subnet_name))
-          network-security-group-name: ((default_security_group))
-          availability-set: ((primary_availability_set))
+          primaryAvailabilitySetName: ((primary_availability_set))
+          resourceGroup: ((resource_group_name))
+          securityGroupName: ((default_security_group))
+          subnetName: ((subnet_name))
+          subscriptionId: ((subscription_id))
+          tenantId: ((tenant_id))
+          useInstanceMetadata: true
+          vnetName: ((vnet_name))
+          vnetResourceGroup: ((vnet_resource_group_name))
     provides:
       cloud-provider: {as: worker-cloud-provider}
 

--- a/manifests/ops-files/iaas/azure/cloud-provider.yml
+++ b/manifests/ops-files/iaas/azure/cloud-provider.yml
@@ -7,20 +7,19 @@
       cloud-provider:
         type: azure
       cloud-config:
-        Global:
-          aadClientId: ((client_id))
-          aadClientSecret: ((client_secret))
-          cloud: ((azure_cloud_name))
-          location: ((location))
-          primaryAvailabilitySetName: ((primary_availability_set))
-          resourceGroup: ((resource_group_name))
-          securityGroupName: ((default_security_group))
-          subnetName: ((subnet_name))
-          subscriptionId: ((subscription_id))
-          tenantId: ((tenant_id))
-          useInstanceMetadata: true
-          vnetName: ((vnet_name))
-          vnetResourceGroup: ((vnet_resource_group_name))
+        aadClientId: ((client_id))
+        aadClientSecret: ((client_secret))
+        cloud: ((azure_cloud_name))
+        location: ((location))
+        primaryAvailabilitySetName: ((primary_availability_set))
+        resourceGroup: ((resource_group_name))
+        securityGroupName: ((default_security_group))
+        subnetName: ((subnet_name))
+        subscriptionId: ((subscription_id))
+        tenantId: ((tenant_id))
+        useInstanceMetadata: true
+        vnetName: ((vnet_name))
+        vnetResourceGroup: ((vnet_resource_group_name))
     provides:
       cloud-provider: {as: master-cloud-provider}
 
@@ -53,20 +52,19 @@
       cloud-provider:
         type: azure
       cloud-config:
-        Global:
-          aadClientId: ((client_id))
-          aadClientSecret: ((client_secret))
-          cloud: ((azure_cloud_name))
-          location: ((location))
-          primaryAvailabilitySetName: ((primary_availability_set))
-          resourceGroup: ((resource_group_name))
-          securityGroupName: ((default_security_group))
-          subnetName: ((subnet_name))
-          subscriptionId: ((subscription_id))
-          tenantId: ((tenant_id))
-          useInstanceMetadata: true
-          vnetName: ((vnet_name))
-          vnetResourceGroup: ((vnet_resource_group_name))
+        aadClientId: ((client_id))
+        aadClientSecret: ((client_secret))
+        cloud: ((azure_cloud_name))
+        location: ((location))
+        primaryAvailabilitySetName: ((primary_availability_set))
+        resourceGroup: ((resource_group_name))
+        securityGroupName: ((default_security_group))
+        subnetName: ((subnet_name))
+        subscriptionId: ((subscription_id))
+        tenantId: ((tenant_id))
+        useInstanceMetadata: true
+        vnetName: ((vnet_name))
+        vnetResourceGroup: ((vnet_resource_group_name))
     provides:
       cloud-provider: {as: worker-cloud-provider}
 

--- a/manifests/ops-files/iaas/gcp/add-service-key-master.yml
+++ b/manifests/ops-files/iaas/gcp/add-service-key-master.yml
@@ -1,3 +1,7 @@
 - type: replace
-  path: /instance_groups/name=master/jobs/name=cloud-provider/properties/cloud-provider/gce/service_key?
+  path: /instance_groups/name=master/jobs/name=cloud-provider/properties/cloud-provider/gce?/service_key?
   value: ((service_key_master))
+
+- type: replace
+  path: /instance_groups/name=master/jobs/name=cloud-provider/properties/cloud-config?/Global?/token-url?
+  value: 'nil'

--- a/manifests/ops-files/iaas/gcp/add-service-key-worker.yml
+++ b/manifests/ops-files/iaas/gcp/add-service-key-worker.yml
@@ -1,3 +1,7 @@
 - type: replace
-  path: /instance_groups/name=worker/jobs/name=cloud-provider/properties/cloud-provider/gce/service_key?
+  path: /instance_groups/name=worker/jobs/name=cloud-provider/properties/cloud-provider/gce?/service_key?
   value: ((service_key_worker))
+
+- type: replace
+  path: /instance_groups/name=worker/jobs/name=cloud-provider/properties/cloud-config?/Global?/token-url?
+  value: 'nil'

--- a/manifests/ops-files/iaas/gcp/add-subnetwork-for-internal-load-balancer.yml
+++ b/manifests/ops-files/iaas/gcp/add-subnetwork-for-internal-load-balancer.yml
@@ -1,7 +1,7 @@
 - type: replace
-  path: /instance_groups/name=master/jobs/name=cloud-provider/properties/cloud-provider/gce/subnetwork-name?
+  path: /instance_groups/name=master/jobs/name=cloud-provider/properties/cloud-config/subnetwork-name?
   value: ((subnetwork))
 
 - type: replace
-  path: /instance_groups/name=worker/jobs/name=cloud-provider/properties/cloud-provider/gce/subnetwork-name?
+  path: /instance_groups/name=worker/jobs/name=cloud-provider/properties/cloud-config/subnetwork-name?
   value: ((subnetwork))

--- a/manifests/ops-files/iaas/gcp/cloud-provider.yml
+++ b/manifests/ops-files/iaas/gcp/cloud-provider.yml
@@ -6,10 +6,11 @@
     properties:
       cloud-provider:
         type: gce
-        gce:
+      cloud-config:
+        Global:
           project-id: ((project_id))
           network-name: ((network))
-          worker-node-tag: ((director_name))-((deployment_name))-worker
+          node-tags: ((director_name))-((deployment_name))-worker
     provides:
       cloud-provider: {as: master-cloud-provider}
 
@@ -36,10 +37,11 @@
     properties:
       cloud-provider:
         type: gce
-        gce:
+      cloud-config:
+        Global:
           project-id: ((project_id))
           network-name: ((network))
-          worker-node-tag: ((director_name))-((deployment_name))-worker
+          node-tags: ((director_name))-((deployment_name))-worker
     provides:
       cloud-provider: {as: worker-cloud-provider}
 

--- a/manifests/ops-files/iaas/openstack/cloud-provider.yml
+++ b/manifests/ops-files/iaas/openstack/cloud-provider.yml
@@ -6,7 +6,8 @@
     properties:
       cloud-provider:
         type: openstack
-        openstack:
+      cloud-config:
+        Global:
           auth-url: ((auth_url))
           domain-name: ((openstack_domain))
           password: ((openstack_password))
@@ -39,7 +40,8 @@
     properties:
       cloud-provider:
         type: openstack
-        openstack:
+      cloud-config:
+        Global:
           auth-url: ((auth_url))
           domain-name: ((openstack_domain))
           password: ((openstack_password))

--- a/manifests/ops-files/iaas/vsphere/cloud-provider.yml
+++ b/manifests/ops-files/iaas/vsphere/cloud-provider.yml
@@ -6,15 +6,16 @@
     properties:
       cloud-provider:
         type: vsphere
-        vsphere:
-          user: ((vcenter_master_user))
-          password: ((vcenter_master_password))
-          server: ((vcenter_ip))
-          insecure-flag: 1
+      cloud-config:
+        Global:
           datacenter: ((vcenter_dc))
           datastore: ((vcenter_ds))
-          vms: ((vcenter_vms))
+          password: ((vcenter_master_password))
+          server: ((vcenter_ip))
+          user: ((vcenter_master_user))
           working-dir: /((vcenter_dc))/vm/((vcenter_vms))/((director_uuid))
+        Disk:
+          scsicontrollertype: pvscsi
     provides:
       cloud-provider: {as: master-cloud-provider}
 

--- a/manifests/ops-files/iaas/vsphere/set-working-dir-no-rp.yml
+++ b/manifests/ops-files/iaas/vsphere/set-working-dir-no-rp.yml
@@ -1,3 +1,3 @@
 - type: replace
-  path: /instance_groups/name=master/jobs/name=cloud-provider/properties/cloud-provider?/vsphere/working-dir
+  path: /instance_groups/name=master/jobs/name=cloud-provider/properties/cloud-config?/working-dir?
   value: /((vcenter_dc))/vm/((vcenter_vms))


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR supports the configurable cloud-config exposed in https://github.com/cloudfoundry-incubator/kubo-release/pull/263 by updating the various ops-files.

**How can this PR be verified?**
Deploy with a cloud-provider and observe that the manifest renders into the expected INI file. Follow up by using a cloud-provider specific bit of functionality like a Load Balancer or Persistent Volume.

**Is there any change in kubo-release?**
[Yes](https://github.com/cloudfoundry-incubator/kubo-release/pull/263).

**Is there any change in kubo-ci?**
No.

**Does this affect upgrade, or is there any migration required?**
Not generally, unless operators are using custom ops-files to enable other cloud-provider options not covered by the default ops-files.

Those operators will need to rewrite the ops-file to move the option to the new format.

**Which issue(s) this PR fixes:**
https://www.pivotaltracker.com/story/show/161421611

**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
* The Kubernetes Cloud Config now accepts pass-through arguments from the BOSH manifest. See kubo-deployment/manifest/ops-files/iaas/<iaas>/cloud-provider.yml for examples.
  * As a result of this change, certain behaviors of the release will no longer occur:
    * In vSphere, the manifest property will need to handle escapes in the username and password fields.
    * In GCP, token-url must explicitly be set to 'nil' when supplying a service-key. See kubo-deployment/manifest/ops-files/iaas/gcp/add-service-key-master.yml for an example.
    * In OpenStack, supplying the OpenStack CA file does _not_ override the OpenStack CA file path. The path needs to be hardcoded into the cloud-config option. By default, that path is `/var/vcap/jobs/cloud-provider/config/openstack-ca.crt`
```