### PR TITLE
Add ops-file to enable CSI shared mounts

### DIFF
--- a/manifests/ops-files/enable-csi-shared-mounts.yml
+++ b/manifests/ops-files/enable-csi-shared-mounts.yml
@@ -1,0 +1,3 @@
+- type: replace
+  path: /instance_groups/name=worker/jobs/name=docker/properties/shared_mounts_enable?
+  value: true


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds an ops-file to allow operators to configure `docker` to enable shared mounts.

**How can this PR be verified?**

When the ops-file is applied, the `docker` job on the `worker` should be configured with `shared_mounts_enable` set to true.

**Is there any change in kubo-release?**

No.

**Is there any change in kubo-ci?**

No.

**Does this affect upgrade, or is there any migration required?**

No.

**Which issue(s) this PR fixes:**

This is required to configure CSI support in Kubernetes. See this [doc](https://kubernetes-csi.github.io/docs/Setup.html#enabling-mount-propagation) for details.

**Release note**:
```release-note
Added an ops-file to enable shared mounts for CSI support. See the [Kubernetes CSI Setup Documentation](https://kubernetes-csi.github.io/docs/Setup.html#enabling-mount-propagation) for details.
```

Please feel free to reach out if you have any questions.

Regards,
Dave