### PR TITLE
Bump to k8s 1.12.2

### DIFF
--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -123,6 +123,7 @@ instance_groups:
       service-account-private-key: ((service-account-key.private_key))
       tls:
         kubernetes: ((tls-kubernetes))
+        kube-controller-manager: ((tls-kube-controller-manager))
       k8s-args:
         cluster-signing-cert-file: /var/vcap/jobs/kube-controller-manager/config/cluster-signing-ca.pem
         cluster-signing-key-file: /var/vcap/jobs/kube-controller-manager/config/cluster-signing-key.pem
@@ -130,6 +131,8 @@ instance_groups:
         root-ca-file: /var/vcap/jobs/kube-controller-manager/config/ca.pem
         service-account-private-key-file: /var/vcap/jobs/kube-controller-manager/config/service-account-private-key.pem
         terminated-pod-gc-threshold: 100
+        tls-cert-file: /var/vcap/jobs/kube-controller-manager/config/kube-controller-manager-cert.pem
+        tls-private-key-file: /var/vcap/jobs/kube-controller-manager/config/kube-controller-manager-private-key.pem
         use-service-account-credentials: true
         v: 2
     release: kubo
@@ -344,6 +347,19 @@ variables:
   type: certificate
 - name: service-account-key
   type: rsa
+- name: tls-kube-controller-manager
+  options:
+    alternative_names:
+    - localhost
+    - 127.0.0.1
+    key_usage:
+    - digital_signature
+    - key_encipherment
+    extended_key_usage:
+    - server_auth
+    ca: kubo_ca
+    common_name: kube-controller-manager
+  type: certificate
 - name: tls-etcd-v0-17-0
   options:
     ca: kubo_ca

--- a/manifests/ops-files/set-certificate-duration.yml
+++ b/manifests/ops-files/set-certificate-duration.yml
@@ -15,9 +15,13 @@
   value: ((certificate-duration))
 
 - type: replace
+  path: /variables/name=tls-kube-controller-manager/options/duration?
+  value: ((certificate-duration))
+
+- type: replace
   path: /variables/name=tls-etcd-v0-17-0/options/duration?
   value: ((certificate-duration))
-  
+
 - type: replace
   path: /variables/name=tls-etcdctl/options/duration?
   value: ((certificate-duration))


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--
Why is this PR important? What is the user impact?
-->
This PR bumps the kubernetes binaries to v1.12.2. Additionally, it includes changes to generate a serving certificate for kube-controller-manager. v1.12.2 now requires either to have a self-signed certificate created to a specified `--cert-dir` or supply the proper certificate and private key via `--tls-cert-file` and `--tls-private-key-file`.

**How can this PR be verified?**
Deploy a CFCR cluster with these changes. Run integration, conformance, and upgrade against it. 

**Is there any change in kubo-release?**
Yes: https://github.com/cloudfoundry-incubator/kubo-release/pull/271

**Is there any change in kubo-ci?**
Nope. 

**Does this affect upgrade, or is there any migration required?**
Yes, because its an update of the k8s binaries. 

**Which issue(s) this PR fixes:**
None. 

**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
* Upgraded to Kubernetes v1.12.2
* New certificate for serving HTTPS from kube-controller-manager
```
