### PR TITLE
Add opsfiles for adding a Windows worker

### DIFF
--- a/bin/test-standard-ops.sh
+++ b/bin/test-standard-ops.sh
@@ -67,6 +67,7 @@ test_standard_ops() {
       check_interpolation "enable-securitycontextdeny.yml"
       check_interpolation "enable-encryption-config.yml" "-v encryption-config=encryption-config.yml"
       check_interpolation "enable-csi-shared-mounts.yml"
+      check_interpolation "use-hostgw.yml"
 
       # Etcd
       check_interpolation "change-etcd-metrics-url.yml" "-v etcd_metrics_protocol=http -v etcd_metrics_port=2378"

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -95,6 +95,7 @@ For deeper documentation to deploy CFCR go [here](https://github.com/cloudfoundr
 | [`ops-files/add-hostname-to-master-certificate.yml`](ops-files/add-hostname-to-master-certificate.yml) | Add hostname to master certificate | Extra Vars Required:<br>- **api-hostname:** Required for TLS certificate of apiserver |
 | [`ops-files/enable-encryption-config.yml`](ops-files/enable-encryption-config.yml) | Enable data encryption at rest | Extra Vars Required:<br>- **encryption-config:** Encryption configuration as described [here](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/#understanding-the-encryption-at-rest-configuration). Var value must be the content of the yaml. Easier to define in a `--vars-file` file |
 | [`ops-files/enable-csi-shared-mounts.yml`](ops-files/enable-csi-shared-mounts.yml) | Enable shared mounts in Docker for CSI volumes | - |
+| [`ops-files/use-hostgw.yml`](ops-files/use-hostgw.yml) | Sets the cluster to use host-gw backend in flannel. Necessary for Windows workers. | - |
 
 ### Etcd
 

--- a/manifests/ops-files/iaas/vsphere/windows/cloud-provider.yml
+++ b/manifests/ops-files/iaas/vsphere/windows/cloud-provider.yml
@@ -1,0 +1,13 @@
+- type: replace
+  path: /instance_groups/name=windows-worker/jobs/name=kubelet-windows/properties/cloud-provider?
+  value: vsphere
+
+- type: replace
+  path: /instance_groups/name=windows-worker/jobs/name=kubelet-windows/consumes?
+  value:
+    cloud-provider: {from: worker-cloud-provider}
+
+- type: replace
+  path: /instance_groups/name=windows-worker/jobs/name=kube-proxy-windows/properties/cloud-provider?
+  value: vsphere
+

--- a/manifests/ops-files/iaas/vsphere/windows/use-vm-extensions.yml
+++ b/manifests/ops-files/iaas/vsphere/windows/use-vm-extensions.yml
@@ -1,0 +1,5 @@
+---
+- type: replace
+  path: /instance_groups/name=windows-worker/vm_extensions?/-
+  value: enable-disk-UUID
+

--- a/manifests/ops-files/misc/deployment-name.yml
+++ b/manifests/ops-files/misc/deployment-name.yml
@@ -1,0 +1,4 @@
+- type: replace
+  path: /name
+  value: ((deployment_name))
+

--- a/manifests/ops-files/misc/version.yml
+++ b/manifests/ops-files/misc/version.yml
@@ -1,0 +1,5 @@
+- type: replace
+  path: /releases/name=kubo
+  value:
+    name: kubo
+    version: ((kubo-version))

--- a/manifests/ops-files/use-hostgw.yml
+++ b/manifests/ops-files/use-hostgw.yml
@@ -1,0 +1,8 @@
+---
+- type: replace
+  path: /instance_groups/name=master/jobs/name=flanneld/properties?/backend-type
+  value: "host-gw"
+- type: replace
+  path: /instance_groups/name=worker/jobs/name=flanneld/properties?/backend-type
+  value: "host-gw"
+

--- a/manifests/ops-files/windows/add-worker.yml
+++ b/manifests/ops-files/windows/add-worker.yml
@@ -1,0 +1,88 @@
+- type: replace
+  path: /stemcells/-
+  value:
+    alias: windows
+    os: windows1803
+    version: latest
+
+- type: replace
+  path: /releases/-
+  value:
+    name: "windows-tools"
+    version: "32"
+    url: "https://bosh.io/d/github.com/cloudfoundry-incubator/windows-tools-release?v=32"
+    sha1: "95b6dd94a0b12491afc95e62f393c4d519411239"
+
+- type: replace
+  path: /instance_groups/-
+  value:
+    name: windows-worker
+    instances: 3
+    azs:
+    - z1
+    - z2
+    - z3
+    networks:
+    - name: default
+    stemcell: windows
+    vm_type: worker
+    jobs:
+    - name: kubelet-windows
+      properties:
+        api-token: ((kubelet-password))
+        kubelet-configuration:
+          kind: KubeletConfiguration
+          apiVersion: kubelet.config.k8s.io/v1beta1
+          authentication:
+            anonymous:
+              enabled: false
+            x509:
+              clientCAFile: C:\var\vcap\jobs\kubelet-windows\config\kubelet-client-ca.pem
+          authorization:
+            mode: Webhook
+          clusterDNS:
+            - 10.100.200.10
+          clusterDomain: cluster.local
+          failSwapOn: false
+          readOnlyPort: 0
+          serializeImagePulls: false
+          tlsCertFile: C:\var\vcap\jobs\kubelet-windows\config\kubelet.pem
+          tlsPrivateKeyFile: C:\var\vcap\jobs\kubelet-windows\config\kubelet-key.pem
+          cgroupsPerQOS: false
+          enforceNodeAllocatable: []
+        drain-api-token: ((kubelet-drain-password))
+        k8s-args:
+          allow-privileged: true
+          cni-bin-dir: C:\var\vcap\jobs\kubelet-windows\packages\cni-windows\bin
+          container-runtime: docker
+          image-pull-progress-deadline: 20m
+          keep-terminated-pod-volumes: false
+          kubeconfig: C:\var\vcap\jobs\kubelet-windows\config\kubeconfig
+          network-plugin: cni
+          pod-infra-container-image: kubeletwin/pause
+          register-with-taints: windows=1803:NoSchedule
+          resolv-conf: ""
+        tls:
+          kubelet: ((tls-kubelet))
+          kubelet-client-ca:
+            certificate: ((tls-kubelet-client.ca))
+          kubernetes: ((tls-kubernetes))
+      release: kubo
+    - name: flanneld-windows
+      release: kubo
+    - name: kube-proxy-windows
+      properties:
+        api-token: ((kube-proxy-password))
+        tls:
+          kubernetes: ((tls-kubernetes))
+        kube-proxy-configuration:
+          apiVersion: kubeproxy.config.k8s.io/v1alpha1
+          kind: KubeProxyConfiguration
+          clusterCIDR: 10.200.0.0/16
+          clientConnection:
+            kubeconfig: /var/vcap/jobs/kube-proxy-windows/config/kubeconfig
+          mode: kernelspace
+          portRange: ""
+      release: kubo
+    - name: docker
+      release: windows-tools

--- a/manifests/ops-files/windows/enable-rdp.yml
+++ b/manifests/ops-files/windows/enable-rdp.yml
@@ -1,0 +1,30 @@
+- type: replace
+  path: /releases/-
+  value:
+    name: "windows-utilities"
+    version: "0.11.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry-incubator/windows-utilities-release?v=0.11.0"
+    sha1: "efc10ac0f4acae23637ce2c6f864d20df2e3a781"
+
+- type: replace
+  path: /addons/-
+  value:
+    name: set-pw
+    include:
+      stemcell:
+      - os: windows1803
+      - os: windows1903
+      - os: windows2019
+    jobs:
+    - name: enable_rdp
+      release: windows-utilities
+      properties:
+        enable_rdp:
+          enabled: true
+    - name: enable_ssh
+      release: windows-utilities
+    - name: set_password
+      release: windows-utilities
+      properties:
+        set_password:
+          password: ((windows-rdp-password))

--- a/manifests/ops-files/windows/scale-to-one-az.yml
+++ b/manifests/ops-files/windows/scale-to-one-az.yml
@@ -1,0 +1,7 @@
+---
+- type: replace
+  path: /instance_groups/name=windows-worker/instances
+  value: 1
+- type: replace
+  path: /instance_groups/name=windows-worker/azs
+  value: [ z1 ]

--- a/manifests/ops-files/windows/use-hostgw.yml
+++ b/manifests/ops-files/windows/use-hostgw.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /instance_groups/name=windows-worker/jobs/name=flanneld-windows/properties?/backend-type
+  value: "win-bridge"

--- a/manifests/ops-files/windows/vm-types.yml
+++ b/manifests/ops-files/windows/vm-types.yml
@@ -1,0 +1,3 @@
+- type: replace
+  path: /instance_groups/name=windows-worker/vm_type
+  value: ((windows_worker_vm_type))


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds the opsfiles for deploying a cluster with a windows worker.

- Windows workers will only support hostgw network backend for now.
- Add ops-file to make linux nodes also use hostgw backend (should be
applied to any cluster with windows workers).
- Add scale-to-one-az opsfile for windows worker (does the same thing as
the standard scale-to-one-az opsfile).

**How can this PR be verified?**
Run test added in kubo-ci PR.

**Is there any change in kubo-release?**
Yes
**Is there any change in kubo-ci?**
Yes
**Does this affect upgrade, or is there any migration required?**
No, as long as you don't add windows nodes to your clusters.
**Which issue(s) this PR fixes:**
Lack of windows support.
**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
Add ops-files for deploying a cluster with windows workers.
```
