### PR TITLE
Update cfcr.yml

### DIFF
--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -271,9 +271,9 @@ instance_groups:
 name: cfcr
 releases:
 - name: kubo
-  sha1: d3f72f85fd5d5ebfcf942117f56c7ac2d6f8d81b
-  url: https://github.com/cloudfoundry-incubator/kubo-release/releases/download/v0.24.0/kubo-release-0.24.0.tgz
   version: 0.24.0
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/kubo-release?v=0.24.0
+  sha1: 96dcd74c99d2a092c7d9d7f21476fb8aa607f54d
 - name: cfcr-etcd
   sha1: 728839a7ddd44757e31ef0fdbcd131c2be23ab0e
   url: https://github.com/cloudfoundry-incubator/cfcr-etcd-release/releases/download/v1.5.0/cfcr-etcd-release-1.5.0.tgz


### PR DESCRIPTION
v0.24.0 note found at https://github.com/cloudfoundry-incubator/kubo-release, so pointing to 
- name: "kubo"
  version: "0.24.0"
  url: "https://bosh.io/d/github.com/cloudfoundry-incubator/kubo-release?v=0.24.0"
  sha1: "96dcd74c99d2a092c7d9d7f21476fb8aa607f54d"

**What this PR does / why we need it**:
<!--
Why is this PR important? What is the user impact?
deployment with v24 fails as no release found 
-->

**How can this PR be verified?**
deploy fro https://github.com/cloudfoundry-incubator/kubo-deployment.git will fail
**Is there any change in kubo-release?**

**Is there any change in kubo-ci?**

**Does this affect upgrade, or is there any migration required?**

**Which issue(s) this PR fixes:**
https://github.com/cloudfoundry-incubator/kubo-deployment/issues/359
**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note

```