### PR TITLE
Added dev operations file for running on bosh-lite

### DIFF
--- a/manifests/ops-files/dev.yml
+++ b/manifests/ops-files/dev.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /instance_groups/name=worker?/persistent_disk
+  value: 1024


### PR DESCRIPTION
### What this PR does / why we need it:
This allows users to run kubo on bosh-lite, where previously it failed due to issues deploying the docker-boshrelease (see https://github.com/cloudfoundry-incubator/docker-boshrelease/pull/123 for more information)
### How can this PR be verified?
Executing within a bosh-lite environment
### Is there any change in kubo-release?
No
### Is there any change in kubo-ci?
No
### Does this affect upgrade, or is there any migration required?
N/A
### Which issue(s) this PR fixes:

## Release note:
Once you have a bosh-lite environment, deploy using the following:
```
./bin/deploy_cfcr_lite -o ../docker-boshrelease/manifests/operators/dev.yml -o manifests/ops-files/dev.yml
```