### PR TITLE
Add  single-worker and use github cpi ops files

### DIFF
--- a/manifests/ops-files/misc/single-worker.yml
+++ b/manifests/ops-files/misc/single-worker.yml
@@ -1,0 +1,3 @@
+- type: replace
+  path: /instance_groups/name=worker/instances
+  value: 1

--- a/manifests/ops-files/use-github-cpi.yml
+++ b/manifests/ops-files/use-github-cpi.yml
@@ -1,0 +1,11 @@
+---
+- type: remove
+  path: /releases/name=bosh-azure-cpi
+
+- type: replace
+  path: /releases/-
+  value:
+    name: bosh-azure-cpi
+    version: v35.4.0-alpha.0
+    url: https://github.com/cloudfoundry/bosh-azure-cpi-release/releases/download/v35.4.0-alpha.0/bosh-azure-cpi-release.tgz
+    sha1: 3f07fa5a5fe7a5cb1d2dd902b955517a2760ca8a


### PR DESCRIPTION
[#162102319](https://www.pivotaltracker.com/story/show/162102319)

Co-authored-by: Sara Montecino <saramontecino@outlook.com>

**What this PR does / why we need it**:
These ops files were pushed to [bbl plan patch](https://github.com/cloudfoundry/bosh-bootloader/tree/master/plan-patches), but seem generic enough to move into this project. 

**How can this PR be verified?**
By following these steps for [bbl azure](https://github.com/cloudfoundry/bosh-bootloader/tree/master/plan-patches/cfcr-azure)
**Is there any change in kubo-release?**
No. 
**Is there any change in kubo-ci?**
No. 
**Does this affect upgrade, or is there any migration required?**
No. 
**Which issue(s) this PR fixes:**
N/A
**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
1. Adds ops file for single worker
2. Adds ops file for azure cpi alpha release
```
cc @cdutra 