### PR TITLE
Updated kube-apiserver's audit log flags to preempt logrotate

### DIFF
--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -207,8 +207,8 @@ instance_groups:
           - RequestReceived
       k8s-args:
         audit-log-maxage: 0
-        audit-log-maxbackup: 0
-        audit-log-maxsize: 10000000
+        audit-log-maxbackup: 7
+        audit-log-maxsize: 49 # Set a max size of 49 so that we can pre-empt logrotate: kubernetes/kubernetes#52865
         audit-log-path: /var/vcap/sys/log/kube-apiserver/audit.log
         audit-policy-file: /var/vcap/jobs/kube-apiserver/config/audit_policy.yml
         authorization-mode: RBAC


### PR DESCRIPTION
**What this PR does / why we need it**:
This works around issue #370, which should ideally be fixed by upstream
Kubernetes. By preempting logrotate, we let kube-apiserver's log
rotation facility handle all rotation. In order to keep in line with
logrotate's behavior, we can also set the maximum number of backups to
7.

**How can this PR be verified?**
Observe audit log rotation and check the backups for corruption.

**Is there any change in kubo-release?**
No.

**Is there any change in kubo-ci?**
No.

**Does this affect upgrade, or is there any migration required?**
No.

**Which issue(s) this PR fixes:**
#370 

**Release note**:
```release-note
* `kube-apiserver` now handles all log rotations for `audit.log` - this should prevent the data corruption seen when `logrotate` would handle the rotation. This behavior may be reverted once https://github.com/kubernetes/kubernetes/issues/52865 has been solved.
```
