### PR TITLE
Ops-files for controlling deployment name and kubo version.

### DIFF
--- a/manifests/ops-files/misc/deployment-name.yml
+++ b/manifests/ops-files/misc/deployment-name.yml
@@ -1,0 +1,4 @@
+- type: replace
+  path: /name
+  value: ((deployment_name))
+

--- a/manifests/ops-files/misc/version.yml
+++ b/manifests/ops-files/misc/version.yml
@@ -1,0 +1,5 @@
+- type: replace
+  path: /releases/name=kubo
+  value:
+    name: kubo
+    version: ((kubo-version))


### PR DESCRIPTION
Signed-off-by: Leah Hanson <lhanson@pivotal.io>

**What this PR does / why we need it**:
Adds ops-files for controlling deployment name and kubo version.

When deploying multiple clusters on the same bosh director, it is necessary to give them different names and sometimes to specify different kubo versions for each one. These ops-files make it easier to change these settings because you can put the values in vars-files rather than changing the base manifest manually every time.

**How can this PR be verified?**
Use these opsfiles, see that you can create a deployment named something other than `cfcr` or with an arbitrary version.

**Is there any change in kubo-deployment?**
No

**Is there any change in kubo-ci?**
No

**Does this affect upgrade, or is there any migration required?**
No

**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
