### PR TITLE
Add opsfile to up fs.inotify limit to allow more file watchers

### DIFF
--- a/bin/test-standard-ops.sh
+++ b/bin/test-standard-ops.sh
@@ -68,6 +68,7 @@ test_standard_ops() {
       check_interpolation "enable-encryption-config.yml" "-v encryption-config=encryption-config.yml"
       check_interpolation "enable-csi-shared-mounts.yml"
       check_interpolation "use-hostgw.yml"
+      check_interpolation "set-fs-inotify-limit.yml" "-l example-vars-files/fs-inotify-limit.yml"
 
       # Etcd
       check_interpolation "change-etcd-metrics-url.yml" "-v etcd_metrics_protocol=http -v etcd_metrics_port=2378"

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -96,6 +96,7 @@ For deeper documentation to deploy CFCR go [here](https://github.com/cloudfoundr
 | [`ops-files/enable-encryption-config.yml`](ops-files/enable-encryption-config.yml) | Enable data encryption at rest | Extra Vars Required:<br>- **encryption-config:** Encryption configuration as described [here](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/#understanding-the-encryption-at-rest-configuration). Var value must be the content of the yaml. Easier to define in a `--vars-file` file |
 | [`ops-files/enable-csi-shared-mounts.yml`](ops-files/enable-csi-shared-mounts.yml) | Enable shared mounts in Docker for CSI volumes | - |
 | [`ops-files/use-hostgw.yml`](ops-files/use-hostgw.yml) | Sets the cluster to use host-gw backend in flannel. Necessary for Windows workers. | - |
+| [`ops-files/set-fs-inotify-limit.yml`](ops-files/set-fs-inotify-limit.yml) | Configure fs.inotify.max_user_watches.| Extra Vars Required:<br>- **fs_inotify_max_user_watches:** Required for configuring the max inotify user watches. |
 
 ### Etcd
 

--- a/manifests/ops-files/example-vars-files/fs-inotify-limit.yml
+++ b/manifests/ops-files/example-vars-files/fs-inotify-limit.yml
@@ -1,0 +1,1 @@
+fs_inotify_max_user_watches: 524288

--- a/manifests/ops-files/set-fs-inotify-limit.yml
+++ b/manifests/ops-files/set-fs-inotify-limit.yml
@@ -1,0 +1,19 @@
+- type: replace
+  path: /addons/-
+  value:
+    jobs:
+      - name: sysctl
+        release: os-conf
+        properties:
+          sysctl:
+          - fs.inotify.max_user_watches=65536
+    name: fs-inotify-limit
+
+- type: replace
+  path: /releases/-
+  value:
+    name: "os-conf"
+    version: "20.0.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/os-conf-release?v=20.0.0"
+    sha1: "a60187f038d45e2886db9df82b72a9ab5fdcc49d"
+

--- a/manifests/ops-files/set-fs-inotify-limit.yml
+++ b/manifests/ops-files/set-fs-inotify-limit.yml
@@ -6,7 +6,7 @@
         release: os-conf
         properties:
           sysctl:
-          - fs.inotify.max_user_watches=65536
+          - fs.inotify.max_user_watches=((fs_inotify_max_user_watches))
     name: fs-inotify-limit
 
 - type: replace

--- a/manifests/ops-files/set-fs-inotify-limit.yml
+++ b/manifests/ops-files/set-fs-inotify-limit.yml
@@ -8,6 +8,10 @@
           sysctl:
           - fs.inotify.max_user_watches=((fs_inotify_max_user_watches))
     name: fs-inotify-limit
+    include:
+      stemcell:
+      - os: ubuntu-trusty
+      - os: ubuntu-xenial
 
 - type: replace
   path: /releases/-


### PR DESCRIPTION
Signed-off-by: Brady Love <blove@pivotal.io>

**What this PR does / why we need it**:
We used this opsfile to up the fs.inotify limit such that fluent-bit's tail plugin does not overwhelm the fs inotify limit. This was added to the master for future work. 
**How can this PR be verified?**
cat /proc/sys/fs/inotify/max_user_watches shows 65k watches
/etc/sysctl.d/71-bosh-os-conf-sysctl.conf shows this line as well. 
**Is there any change in kubo-release?**
No
**Is there any change in kubo-ci?**
We didn't add any changes, but can if needed for testing etc.
**Does this affect upgrade, or is there any migration required?**
No
**Which issue(s) this PR fixes:**
https://www.pivotaltracker.com/story/show/164228988
**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
Added a opsfile to up fs.inotify limit for log watching. 
```
