### PR TITLE
Template bbr.backup_one_restore_all property for bbr-etcd job

### DIFF
--- a/manifests/ops-files/enable-bbr.yml
+++ b/manifests/ops-files/enable-bbr.yml
@@ -3,6 +3,9 @@
   value:
     name: bbr-etcd
     release: cfcr-etcd
+    properties:
+      bbr:
+        backup_one_restore_all: true
 
 - type: replace
   path: /instance_groups/name=master/jobs/-


### PR DESCRIPTION
As part of a [PR into cfcr-etcd](https://github.com/alamages/kubo-deployment/tree/bbr-backup-one-restore-all) we introduced a new manifest property for the etcd bbr job. This PR is to add it to the ops file that enables the job. This property enables BBR to backup and restore multi-master clusters when using version [v1.5.0 and later](https://github.com/cloudfoundry-incubator/bosh-backup-and-restore/releases/tag/v1.5.0).

Thanks,
Jake & @MModhaPivotal