### PR TITLE
Set the root-dir to a partition that is scalable

### DIFF
--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -352,6 +352,7 @@ instance_groups:
         docker-endpoint: unix:///var/vcap/sys/run/docker/docker.sock
         kubeconfig: /var/vcap/jobs/kubelet/config/kubeconfig
         network-plugin: cni
+        root-dir: /var/vcap/data/kubelet
       kubelet-configuration:
         apiVersion: kubelet.config.k8s.io/v1beta1
         authentication:


### PR DESCRIPTION
...so that it is possible to avoid eviction thresholds when log files grow

**What this  does / why we need it**:
Fixes the bug described here:
https://www.pivotaltracker.com/story/show/164157527

**How can this  be verified?**
Deploy CFCR. Create and run a pod that writes data to an emptyDir type volume (sample code can be found [here](https://matthewpalmer.net/kubernetes-app-developer/articles/kubernetes-volumes-example-nfs-persistent-volume.html), and observe that it writes data into the `/var/vcap/data/kubelet` mount point. The specific path on each worker VM will be something like: `/var/vcap/data/kubelet/pods/xxxxxxx-xxxx-xxxxxxxx/volumes/kubernetes.io~empty-dir/simple-vol/file.txt`

**Is there any change in kubo-release?**
No

**Is there any change in kubo-ci?**
No (but should there be?)

**Does this affect upgrade, or is there any migration required?**
No

**Which issue(s) does this fixes?**
Tracker #164157527

**Release note**:
TBD by PMs
