### PR TITLE
Update Windows workers to use 2019 stemcells

### DIFF
--- a/manifests/ops-files/windows/add-worker.yml
+++ b/manifests/ops-files/windows/add-worker.yml
@@ -62,6 +62,7 @@
           pod-infra-container-image: kubeletwin/pause
           register-with-taints: windows=2019:NoSchedule
           resolv-conf: ""
+          runtime-request-timeout: 1m
         tls:
           kubelet: ((tls-kubelet))
           kubelet-client-ca:

--- a/manifests/ops-files/windows/add-worker.yml
+++ b/manifests/ops-files/windows/add-worker.yml
@@ -2,7 +2,7 @@
   path: /stemcells/-
   value:
     alias: windows
-    os: windows1803
+    os: windows2019
     version: latest
 
 - type: replace
@@ -60,7 +60,7 @@
           kubeconfig: C:\var\vcap\jobs\kubelet-windows\config\kubeconfig
           network-plugin: cni
           pod-infra-container-image: kubeletwin/pause
-          register-with-taints: windows=1803:NoSchedule
+          register-with-taints: windows=2019:NoSchedule
           resolv-conf: ""
         tls:
           kubelet: ((tls-kubelet))


### PR DESCRIPTION
**What this PR does / why we need it**:

1. **Updates windows workers to run on 2019.** This updates the expected OS version of the stemcell and the value of the taint for the windows nodes. In order for this PR to pass in your CI pipeline, you'll need to adjust the job that uploads the windows stemcell to the Bosh director, to upload a 2019 stemcell.

2. **Sets `runtime-request-timeout` on windows.** Setting this property causes some kubelet requests that don't normally have a timeout to have a timeout set. The goal is to work around some instability caused by [hangs like this one](https://github.com/kubernetes/kubernetes/issues/75299).

**How can this PR be verified?**

On a bosh director where the only windows stemcell is 2019, deploy the cluster as usual in host-gw mode and see that it works.

**Is there any change in kubo-release?**
Yes

**Is there any change in kubo-ci?**
It needs to upload a 2019 stemcell.

**Does this affect upgrade, or is there any migration required?**

**Which issue(s) this PR fixes:**
Kubernetes windows support will GA with official support _only_ for 2019. Currently, CFCR only supports 1803; this PR fixes that.

**Release note**:
(this is covered by existing "adds windows support" release note)
```release-note
NONE
```
