### PR TITLE
Add name keys to Windows releases to allow autobumping

### DIFF
--- a/manifests/ops-files/windows/add-worker.yml
+++ b/manifests/ops-files/windows/add-worker.yml
@@ -5,8 +5,10 @@
     os: windows2019
     version: latest
 
-- type: replace
+- name: windows-tools
+  note: the name key is necessary for bump-boshrelease.sh
   path: /releases/-
+  type: replace
   value:
     name: "windows-tools"
     version: "32"

--- a/manifests/ops-files/windows/enable-rdp.yml
+++ b/manifests/ops-files/windows/enable-rdp.yml
@@ -1,4 +1,6 @@
-- type: replace
+- name: windows-utilities
+  note: the name key is necessary for bump-boshrelease.sh
+  type: replace
   path: /releases/-
   value:
     name: "windows-utilities"


### PR DESCRIPTION
**What this PR does / why we need it**:
We're adapting the ci bump-boshrelease job to be able to bump these opsfiles releases. We needed to add a `name` key to them so that the opsfile can target them.

**How can this PR be verified?**
No need

**Is there any change in kubo-release?**
No
**Is there any change in kubo-ci?**
Yes: https://github.com/cloudfoundry-incubator/kubo-ci/pull/50
**Does this affect upgrade, or is there any migration required?**
No
**Which issue(s) this PR fixes:**

**Release note**:
```release-note
NONE
```
