### PR TITLE
Update windows/add-worker.yml to fetch external windows release

### DIFF
--- a/manifests/ops-files/windows/add-worker.yml
+++ b/manifests/ops-files/windows/add-worker.yml
@@ -14,6 +14,14 @@
     sha1: "95b6dd94a0b12491afc95e62f393c4d519411239"
 
 - type: replace
+  path: /releases/-
+  value:
+    name: "kubo-windows"
+    version: 0.31.0
+    url: https://storage.googleapis.com/kubo-precompiled-releases/kubo-windows-0.31.0-windows2019-2019.2-20190321-144654-567645.tgz
+    sha1: 9c7fad7e74640f983f9ddf4115e032f23a4230d6
+
+- type: replace
   path: /instance_groups/-
   value:
     name: windows-worker
@@ -68,9 +76,9 @@
           kubelet-client-ca:
             certificate: ((tls-kubelet-client.ca))
           kubernetes: ((tls-kubernetes))
-      release: kubo
+      release: kubo-windows
     - name: flanneld-windows
-      release: kubo
+      release: kubo-windows
     - name: kube-proxy-windows
       properties:
         api-token: ((kube-proxy-password))
@@ -84,6 +92,6 @@
             kubeconfig: /var/vcap/jobs/kube-proxy-windows/config/kubeconfig
           mode: kernelspace
           portRange: ""
-      release: kubo
+      release: kubo-windows
     - name: docker
       release: windows-tools


### PR DESCRIPTION
**What this PR does / why we need it**:
Windows support now exists in a separate release and so it needs to be consumed.

**How can this PR be verified?**
Deploy a Windows worker using the ops-file.

**Is there any change in kubo-release?**
No.

**Is there any change in kubo-ci?**
CI also needs to be updated to consume the external release - pending.

**Does this affect upgrade, or is there any migration required?**
No.

**Which issue(s) this PR fixes:**
None.