### PR TITLE
Bump ulimit to be the same as in GKE

### DIFF
--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -329,7 +329,7 @@ instance_groups:
     properties:
       bridge: cni0
       default_ulimits:
-      - nofile=65536
+      - nofile=1048576
       env: {}
       flannel: true
       ip_masq: false


### PR DESCRIPTION
**What this PR does / why we need it**:
I would like to have better `ulimit` by default.

**How can this PR be verified?**
https://github.com/cloudfoundry-incubator/kubo-ci/blob/master/src/tests/integration-tests/generic/ulimit_test.go#L25

**Is there any change in kubo-release?**
Nope

**Is there any change in kubo-ci?**
Maybe change test to have bigger default, but not required

**Does this affect upgrade, or is there any migration required?**
NA

**Which issue(s) this PR fixes:**
I can't start Eirini on default CFCR cluster.

**Release note**:
```release-note
Bump ulimit to 1048576
```
