### PR TITLE
Add opsfile for setting windows overlay vni/port

### DIFF
--- a/manifests/ops-files/windows/use-overlay.yml
+++ b/manifests/ops-files/windows/use-overlay.yml
@@ -1,0 +1,7 @@
+---
+- type: replace
+  path: /instance_groups/name=worker/jobs/name=flanneld/properties?/vni
+  value: 4096
+- type: replace
+  path: /instance_groups/name=worker/jobs/name=flanneld/properties?/port
+  value: 4789


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows Windows deployments to override the vni/port used for the cluster

**How can this PR be verified?**
Same as https://github.com/cloudfoundry-incubator/kubo-release/pull/320

**Is there any change in kubo-release?**
Yes

**Is there any change in kubo-ci?**
No

**Does this affect upgrade, or is there any migration required?**
No

**Release note**:
```release-note
Adds an opsfile to support setting vxlan VNI and port to values supported by Windows
```
