### PR TITLE
Add tls-etcdctl-root to set-certificate-duration.yml

### DIFF
--- a/manifests/ops-files/set-certificate-duration.yml
+++ b/manifests/ops-files/set-certificate-duration.yml
@@ -31,6 +31,10 @@
   value: ((certificate-duration))
 
 - type: replace
+  path: /variables/name=tls-etcdctl-root/options/duration?
+  value: ((certificate-duration))
+
+- type: replace
   path: /variables/name=tls-etcdctl-flanneld/options/duration?
   value: ((certificate-duration))
 


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--
Why is this PR important? What is the user impact?
-->
Forget to add new cert to update duration opsfile
**How can this PR be verified?**

**Is there any change in kubo-release?**
No
**Is there any change in kubo-ci?**
No
**Does this affect upgrade, or is there any migration required?**
No
**Which issue(s) this PR fixes:**

**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note

```
