### PR TITLE
Azure/GCP

### DIFF
--- a/manifests/ops-files/iaas/aws/windows/cloud-provider.yml
+++ b/manifests/ops-files/iaas/aws/windows/cloud-provider.yml
@@ -1,0 +1,21 @@
+- type: replace
+  path: /instance_groups/name=windows-worker/jobs/-
+  value:
+    name: cloud-provider
+    release: kubo
+    properties:
+      cloud-provider:
+        type: aws
+
+- type: replace
+  path: /instance_groups/name=windows-worker/jobs/name=kubelet-windows/consumes?
+  value:
+    cloud-provider: {from: worker-cloud-provider}
+
+- type: replace
+  path: /instance_groups/name=windows-worker/jobs/name=kubelet-windows/properties/cloud-provider?
+  value: aws
+
+- type: replace
+  path: /instance_groups/name=windows-worker/jobs/name=kube-proxy-windows/properties/cloud-provider?
+  value: aws

--- a/manifests/ops-files/iaas/azure/windows/apiserver-address-types.yml
+++ b/manifests/ops-files/iaas/azure/windows/apiserver-address-types.yml
@@ -1,0 +1,3 @@
+- type: replace
+  path: /instance_groups/name=master/jobs/name=kube-apiserver/properties/k8s-args/kubelet-preferred-address-types?
+  value: InternalIP,ExternalIP,Hostname

--- a/manifests/ops-files/iaas/azure/windows/cloud-provider.yml
+++ b/manifests/ops-files/iaas/azure/windows/cloud-provider.yml
@@ -1,0 +1,35 @@
+- type: replace
+  path: /instance_groups/name=windows-worker/jobs/-
+  value:
+    name: cloud-provider
+    release: kubo
+    properties:
+      cloud-provider:
+        type: azure
+      cloud-config:
+        useManagedIdentityExtension: true
+        cloud: ((azure_cloud_name))
+        location: ((location))
+        primaryAvailabilitySetName: ((primary_availability_set))
+        resourceGroup: ((resource_group_name))
+        securityGroupName: ((default_security_group))
+        subnetName: ((subnet_name))
+        subscriptionId: ((subscription_id))
+        tenantId: ((tenant_id))
+        useInstanceMetadata: true
+        vnetName: ((vnet_name))
+        vnetResourceGroup: ((vnet_resource_group_name))
+        loadBalancerSku: standard
+
+- type: replace
+  path: /instance_groups/name=windows-worker/jobs/name=kubelet-windows/consumes?
+  value:
+    cloud-provider: {from: worker-cloud-provider}
+
+- type: replace
+  path: /instance_groups/name=windows-worker/jobs/name=kubelet-windows/properties/cloud-provider?
+  value: azure
+
+- type: replace
+  path: /instance_groups/name=windows-worker/jobs/name=kube-proxy-windows/properties/cloud-provider?
+  value: azure

--- a/manifests/ops-files/iaas/gcp/windows/add-service-key-worker.yml
+++ b/manifests/ops-files/iaas/gcp/windows/add-service-key-worker.yml
@@ -1,0 +1,7 @@
+- type: replace
+  path: /instance_groups/name=windows-worker/jobs/name=cloud-provider/properties/cloud-provider/gce?/service_key?
+  value: ((service_key_worker))
+
+- type: replace
+  path: /instance_groups/name=windows-worker/jobs/name=cloud-provider/properties/cloud-config?/Global?/token-url?
+  value: 'nil'

--- a/manifests/ops-files/iaas/gcp/windows/add-subnetwork-for-internal-load-balancer.yml
+++ b/manifests/ops-files/iaas/gcp/windows/add-subnetwork-for-internal-load-balancer.yml
@@ -1,0 +1,3 @@
+- type: replace
+  path: /instance_groups/name=windows-worker/jobs/name=cloud-provider/properties/cloud-config?/Global?/subnetwork-name?
+  value: ((subnetwork))

--- a/manifests/ops-files/iaas/gcp/windows/cloud-provider.yml
+++ b/manifests/ops-files/iaas/gcp/windows/cloud-provider.yml
@@ -1,0 +1,28 @@
+- type: replace
+  path: /instance_groups/name=windows-worker/jobs/-
+  value:
+    name: cloud-provider
+    release: kubo
+    properties:
+      cloud-provider:
+        type: gce
+      cloud-config:
+        Global:
+          project-id: ((project_id))
+          network-name: ((network))
+          node-tags: ((director_name))-((deployment_name))-worker
+
+- type: replace
+  path: /instance_groups/name=windows-worker/jobs/name=kubelet-windows/properties/cloud-provider?
+  value: gce
+
+- type: replace
+  path: /instance_groups/name=windows-worker/jobs/name=kubelet-windows/consumes?
+  value:
+    cloud-provider: {from: worker-cloud-provider}
+
+- type: replace
+  path: /instance_groups/name=windows-worker/jobs/name=kube-proxy-windows/properties/cloud-provider?
+  value: gce
+
+

--- a/manifests/ops-files/iaas/gcp/windows/ephemeral-disk.yml
+++ b/manifests/ops-files/iaas/gcp/windows/ephemeral-disk.yml
@@ -1,0 +1,5 @@
+---
+- type: replace
+  path: /instance_groups/name=windows-worker/vm_extensions?/-
+  value: ((windows_ephemeral_disk_type))
+

--- a/manifests/ops-files/windows/add-worker.yml
+++ b/manifests/ops-files/windows/add-worker.yml
@@ -71,7 +71,6 @@
           enforceNodeAllocatable: []
         drain-api-token: ((kubelet-drain-password))
         k8s-args:
-          allow-privileged: true
           cni-bin-dir: C:\var\vcap\jobs\kubelet-windows\packages\cni-windows\bin
           container-runtime: docker
           image-pull-progress-deadline: 20m

--- a/manifests/ops-files/windows/increase-disk.yml
+++ b/manifests/ops-files/windows/increase-disk.yml
@@ -1,0 +1,5 @@
+---
+- type: replace
+  path: /instance_groups/name=windows-worker/vm_extensions?/-
+  value: ((deployment_name))-windows-worker-cloud-properties
+

--- a/manifests/ops-files/windows/increase-disk.yml
+++ b/manifests/ops-files/windows/increase-disk.yml
@@ -1,5 +1,0 @@
----
-- type: replace
-  path: /instance_groups/name=windows-worker/vm_extensions?/-
-  value: ((deployment_name))-windows-worker-cloud-properties
-

--- a/manifests/ops-files/windows/overlay-overrides.yml
+++ b/manifests/ops-files/windows/overlay-overrides.yml
@@ -1,0 +1,13 @@
+---
+- type: replace
+  path: /instance_groups/name=master/jobs/name=flanneld/properties?/vni
+  value: 4096
+- type: replace
+  path: /instance_groups/name=master/jobs/name=flanneld/properties?/port
+  value: 4789
+- type: replace
+  path: /instance_groups/name=worker/jobs/name=flanneld/properties?/vni
+  value: 4096
+- type: replace
+  path: /instance_groups/name=worker/jobs/name=flanneld/properties?/port
+  value: 4789

--- a/manifests/ops-files/windows/stemcell.yml
+++ b/manifests/ops-files/windows/stemcell.yml
@@ -1,0 +1,3 @@
+- type: replace
+  path: /stemcells/alias=windows/version
+  value: ((windows-stemcell-version))

--- a/manifests/ops-files/windows/use-vm-extensions.yml
+++ b/manifests/ops-files/windows/use-vm-extensions.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /instance_groups/name=windows-worker/vm_extensions?/-
+  value: ((deployment_name))-worker-cloud-properties

--- a/manifests/ops-files/windows/version.yml
+++ b/manifests/ops-files/windows/version.yml
@@ -1,0 +1,5 @@
+- type: replace
+  path: /releases/name=kubo-windows
+  value:
+    name: kubo-windows
+    version: ((kubo-windows-version))


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for Azure/GCP Windows cloud providers

**How can this PR be verified?**
Deploy Windows workers to those environments

**Is there any change in kubo-release?**
No

**Is there any change in kubo-ci?**
No

**Does this affect upgrade, or is there any migration required?**
No

**Which issue(s) this PR fixes:**
None

**Release note**:
```release-note
Add opsfiles for configuring Windows workers on Azure and GCP
```

This is built on top of #392