### PR TITLE
Add aws cloud provider for Windows nodes

### DIFF
--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -359,7 +359,7 @@ instance_groups:
     properties:
       bridge: cni0
       default_ulimits:
-      - nofile=65536
+      - nofile=1048576
       env: {}
       flannel: true
       ip_masq: false

--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -443,16 +443,16 @@ releases:
   url: https://storage.googleapis.com/kubo-precompiled-releases/kubo-0.32.0-ubuntu-xenial-315.11-20190503-013515-207132992.tgz
   version: 0.32.0
 - name: cfcr-etcd
-  sha1: 0b50c71309b183a6df0d9ed323bd9121e0f52b7b
-  url: https://storage.googleapis.com/kubo-precompiled-releases/cfcr-etcd-1.11.1-ubuntu-xenial-315.11-20190501-204615-484815995.tgz
+  sha1: 5380f4a39c195dd0d37efdf349de63aacb3dc23a
+  url: https://storage.googleapis.com/kubo-precompiled-releases/cfcr-etcd-1.11.1-ubuntu-xenial-315.13-20190508-232853-275875834.tgz
   version: 1.11.1
 - name: docker
-  sha1: 490d9bf8680e40f95db80ab154db36fbd14a5020
-  url: https://storage.googleapis.com/kubo-precompiled-releases/docker-35.2.1-ubuntu-xenial-315.11-20190426-201158-613984596.tgz
+  sha1: be8ad2890f892b59a2af58bcfcd329988fd6bcbb
+  url: https://storage.googleapis.com/kubo-precompiled-releases/docker-35.2.1-ubuntu-xenial-315.13-20190508-232444-336096812.tgz
   version: 35.2.1
 - name: bpm
-  sha1: 5d142971eccc81cee49741364d15bd8d51b4a1fe
-  url: https://storage.googleapis.com/kubo-precompiled-releases/bpm-1.0.4-ubuntu-xenial-315.11-20190426-010134-221216876.tgz
+  sha1: 9afa402f92a8a77f9fe94d1d151a3b94732a98b0
+  url: https://storage.googleapis.com/kubo-precompiled-releases/bpm-1.0.4-ubuntu-xenial-315.13-20190508-233437-547410377.tgz
   version: 1.0.4
 stemcells:
 - alias: default

--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -457,7 +457,7 @@ releases:
 stemcells:
 - alias: default
   os: ubuntu-xenial
-  version: 315.11
+  version: 315.13
 update:
   canaries: 1
   canary_watch_time: 10000-300000

--- a/manifests/ops-files/iaas/aws/windows/cloud-provider.yml
+++ b/manifests/ops-files/iaas/aws/windows/cloud-provider.yml
@@ -1,0 +1,21 @@
+- type: replace
+  path: /instance_groups/name=windows-worker/jobs/-
+  value:
+    name: cloud-provider
+    release: kubo
+    properties:
+      cloud-provider:
+        type: aws
+
+- type: replace
+  path: /instance_groups/name=windows-worker/jobs/name=kubelet-windows/consumes?
+  value:
+    cloud-provider: {from: worker-cloud-provider}
+
+- type: replace
+  path: /instance_groups/name=windows-worker/jobs/name=kubelet-windows/properties/cloud-provider?
+  value: aws
+
+- type: replace
+  path: /instance_groups/name=windows-worker/jobs/name=kube-proxy-windows/properties/cloud-provider?
+  value: aws

--- a/manifests/ops-files/windows/add-worker.yml
+++ b/manifests/ops-files/windows/add-worker.yml
@@ -90,6 +90,12 @@
       release: kubo-windows
     - name: flanneld-windows
       release: kubo-windows
+      properties:
+        tls:
+          etcdctl:
+            ca: ((tls-etcdctl-flanneld.ca))
+            certificate: ((tls-etcdctl-flanneld.certificate))
+            private_key: ((tls-etcdctl-flanneld.private_key))
     - name: kube-proxy-windows
       properties:
         api-token: ((kube-proxy-password))

--- a/manifests/ops-files/windows/use-overlay.yml
+++ b/manifests/ops-files/windows/use-overlay.yml
@@ -1,0 +1,7 @@
+---
+- type: replace
+  path: /instance_groups/name=worker/jobs/name=flanneld/properties?/vni
+  value: 4096
+- type: replace
+  path: /instance_groups/name=worker/jobs/name=flanneld/properties?/port
+  value: 4789


### PR DESCRIPTION
Adds an opsfile for Windows workers running on AWS.

Here's the opsfile set I've been using for deploying on AWS with a director deployed with https://github.com/cloudfoundry/bosh-bootloader/tree/master/plan-patches/cfcr-aws

```
bosh -d cfcr -n deploy ~/workspace/kubo-deployment/manifests/cfcr.yml \
  -v kubo-version=latest \
  -v kubo-windows-version=latest \
  -v windows-rdp-password="Foobar123!" \
  -v windows-stemcell-version=latest \
  -v deployment_name=cfcr \
  -v windows_worker_vm_type=large \
  -v master_vm_type=default \
  -v worker_vm_type=default \
  -v apply_addons_vm_type=default \
  -o ~/workspace/kubo-deployment/manifests/ops-files/misc/single-master.yml \
  -o ~/workspace/kubo-deployment/manifests/ops-files/allow-privileged-containers.yml \
  -o ~/workspace/kubo-deployment/manifests/ops-files/misc/version.yml \
  -o ~/workspace/kubo-deployment/manifests/ops-files/vm-types.yml \
  -o ~/workspace/kubo-deployment/manifests/ops-files/use-vm-extensions.yml \
  -o ~/workspace/kubo-deployment/manifests/ops-files/add-hostname-to-master-certificate.yml \
  -o ~/workspace/kubo-deployment/manifests/ops-files/misc/scale-to-one-az.yml \
  -o ~/workspace/kubo-deployment/manifests/ops-files/iaas/aws/cloud-provider.yml \
  -o ~/workspace/kubo-deployment/manifests/ops-files/iaas/aws/lb.yml \
  -l <(bbl outputs --state-dir ~/workspace/environments/aws) \
  -o ~/workspace/kubo-deployment/manifests/ops-files/windows/add-worker.yml \
  -o ~/workspace/kubo-deployment/manifests/ops-files/windows/use-overlay.yml \
  -o ~/workspace/kubo-deployment/manifests/ops-files/windows/enable-rdp.yml \
  -o ~/workspace/kubo-deployment/manifests/ops-files/windows/version.yml \
  -o ~/workspace/kubo-deployment/manifests/ops-files/windows/stemcell.yml \
  -o ~/workspace/kubo-deployment/manifests/ops-files/windows/vm-types.yml \
  -o ~/workspace/kubo-deployment/manifests/ops-files/iaas/aws/windows/cloud-provider.yml \
  -o ~/workspace/kubo-deployment/manifests/ops-files/windows/use-vm-extensions.yml \
  -o ~/workspace/kubo-deployment/manifests/ops-files/windows/scale-to-one-az.yml
```

An important note with AWS is that we've discovered a bug with Windows networking and AWS' [Enhanced Networking](https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/sriov-networking.html) feature. We need to avoid these VM types (`C3, C4, D2, I2, M4 (excluding m4.16xlarge), and R3`) for now. I'm using `m5.xlarge` for my Windows VMs.