### PR TITLE
Remove deprecated flag from Windows worker

### DIFF
--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -359,7 +359,7 @@ instance_groups:
     properties:
       bridge: cni0
       default_ulimits:
-      - nofile=65536
+      - nofile=1048576
       env: {}
       flannel: true
       ip_masq: false

--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -443,16 +443,16 @@ releases:
   url: https://storage.googleapis.com/kubo-precompiled-releases/kubo-0.32.0-ubuntu-xenial-315.11-20190503-013515-207132992.tgz
   version: 0.32.0
 - name: cfcr-etcd
-  sha1: 0b50c71309b183a6df0d9ed323bd9121e0f52b7b
-  url: https://storage.googleapis.com/kubo-precompiled-releases/cfcr-etcd-1.11.1-ubuntu-xenial-315.11-20190501-204615-484815995.tgz
+  sha1: 5380f4a39c195dd0d37efdf349de63aacb3dc23a
+  url: https://storage.googleapis.com/kubo-precompiled-releases/cfcr-etcd-1.11.1-ubuntu-xenial-315.13-20190508-232853-275875834.tgz
   version: 1.11.1
 - name: docker
-  sha1: 490d9bf8680e40f95db80ab154db36fbd14a5020
-  url: https://storage.googleapis.com/kubo-precompiled-releases/docker-35.2.1-ubuntu-xenial-315.11-20190426-201158-613984596.tgz
+  sha1: be8ad2890f892b59a2af58bcfcd329988fd6bcbb
+  url: https://storage.googleapis.com/kubo-precompiled-releases/docker-35.2.1-ubuntu-xenial-315.13-20190508-232444-336096812.tgz
   version: 35.2.1
 - name: bpm
-  sha1: 5d142971eccc81cee49741364d15bd8d51b4a1fe
-  url: https://storage.googleapis.com/kubo-precompiled-releases/bpm-1.0.4-ubuntu-xenial-315.11-20190426-010134-221216876.tgz
+  sha1: 9afa402f92a8a77f9fe94d1d151a3b94732a98b0
+  url: https://storage.googleapis.com/kubo-precompiled-releases/bpm-1.0.4-ubuntu-xenial-315.13-20190508-233437-547410377.tgz
   version: 1.0.4
 stemcells:
 - alias: default

--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -457,7 +457,7 @@ releases:
 stemcells:
 - alias: default
   os: ubuntu-xenial
-  version: 315.13
+  version: 315.22
 update:
   canaries: 1
   canary_watch_time: 10000-300000

--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -457,7 +457,7 @@ releases:
 stemcells:
 - alias: default
   os: ubuntu-xenial
-  version: 315.11
+  version: 315.13
 update:
   canaries: 1
   canary_watch_time: 10000-300000

--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -443,16 +443,16 @@ releases:
   url: https://storage.googleapis.com/kubo-precompiled-releases/kubo-0.32.0-ubuntu-xenial-315.11-20190503-013515-207132992.tgz
   version: 0.32.0
 - name: cfcr-etcd
-  sha1: 5380f4a39c195dd0d37efdf349de63aacb3dc23a
-  url: https://storage.googleapis.com/kubo-precompiled-releases/cfcr-etcd-1.11.1-ubuntu-xenial-315.13-20190508-232853-275875834.tgz
+  sha1: 649f691852cbc3bb6abf2566b6661e73050bf7b9
+  url: https://storage.googleapis.com/kubo-precompiled-releases/cfcr-etcd-1.11.1-ubuntu-xenial-315.22-20190514-223748-87686803.tgz
   version: 1.11.1
 - name: docker
-  sha1: be8ad2890f892b59a2af58bcfcd329988fd6bcbb
-  url: https://storage.googleapis.com/kubo-precompiled-releases/docker-35.2.1-ubuntu-xenial-315.13-20190508-232444-336096812.tgz
+  sha1: be73e08366e44c405817ee73596b751278f017e1
+  url: https://storage.googleapis.com/kubo-precompiled-releases/docker-35.2.1-ubuntu-xenial-315.22-20190514-223351-918040569.tgz
   version: 35.2.1
 - name: bpm
-  sha1: 9afa402f92a8a77f9fe94d1d151a3b94732a98b0
-  url: https://storage.googleapis.com/kubo-precompiled-releases/bpm-1.0.4-ubuntu-xenial-315.13-20190508-233437-547410377.tgz
+  sha1: 3b4bc3f4f67b5a31c613c9571ee3280a78495fd1
+  url: https://storage.googleapis.com/kubo-precompiled-releases/bpm-1.0.4-ubuntu-xenial-315.22-20190514-224348-971909998.tgz
   version: 1.0.4
 stemcells:
 - alias: default

--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -443,16 +443,16 @@ releases:
   url: https://storage.googleapis.com/kubo-precompiled-releases/kubo-0.32.0-ubuntu-xenial-315.11-20190503-013515-207132992.tgz
   version: 0.32.0
 - name: cfcr-etcd
-  sha1: 649f691852cbc3bb6abf2566b6661e73050bf7b9
-  url: https://storage.googleapis.com/kubo-precompiled-releases/cfcr-etcd-1.11.1-ubuntu-xenial-315.22-20190514-223748-87686803.tgz
+  sha1: fb06dd353963ac043e3b4d14eeaf8ab90374dd3b
+  url: https://storage.googleapis.com/kubo-precompiled-releases/cfcr-etcd-1.11.1-ubuntu-xenial-315.34-20190523-232135-884887987.tgz
   version: 1.11.1
 - name: docker
-  sha1: be73e08366e44c405817ee73596b751278f017e1
-  url: https://storage.googleapis.com/kubo-precompiled-releases/docker-35.2.1-ubuntu-xenial-315.22-20190514-223351-918040569.tgz
+  sha1: 38fe06e4258af021d7a869a949a50ce51d285656
+  url: https://storage.googleapis.com/kubo-precompiled-releases/docker-35.2.1-ubuntu-xenial-315.34-20190523-231739-405970539.tgz
   version: 35.2.1
 - name: bpm
-  sha1: 3b4bc3f4f67b5a31c613c9571ee3280a78495fd1
-  url: https://storage.googleapis.com/kubo-precompiled-releases/bpm-1.0.4-ubuntu-xenial-315.22-20190514-224348-971909998.tgz
+  sha1: 303a18957075265dc3317c8974480d548afdff65
+  url: https://storage.googleapis.com/kubo-precompiled-releases/bpm-1.0.4-ubuntu-xenial-315.34-20190523-232708-452527405.tgz
   version: 1.0.4
 stemcells:
 - alias: default

--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -457,7 +457,7 @@ releases:
 stemcells:
 - alias: default
   os: ubuntu-xenial
-  version: 315.22
+  version: 315.34
 update:
   canaries: 1
   canary_watch_time: 10000-300000

--- a/manifests/ops-files/windows/add-worker.yml
+++ b/manifests/ops-files/windows/add-worker.yml
@@ -90,6 +90,12 @@
       release: kubo-windows
     - name: flanneld-windows
       release: kubo-windows
+      properties:
+        tls:
+          etcdctl:
+            ca: ((tls-etcdctl-flanneld.ca))
+            certificate: ((tls-etcdctl-flanneld.certificate))
+            private_key: ((tls-etcdctl-flanneld.private_key))
     - name: kube-proxy-windows
       properties:
         api-token: ((kube-proxy-password))

--- a/manifests/ops-files/windows/add-worker.yml
+++ b/manifests/ops-files/windows/add-worker.yml
@@ -71,7 +71,6 @@
           enforceNodeAllocatable: []
         drain-api-token: ((kubelet-drain-password))
         k8s-args:
-          allow-privileged: true
           cni-bin-dir: C:\var\vcap\jobs\kubelet-windows\packages\cni-windows\bin
           container-runtime: docker
           image-pull-progress-deadline: 20m

--- a/manifests/ops-files/windows/use-overlay.yml
+++ b/manifests/ops-files/windows/use-overlay.yml
@@ -1,0 +1,7 @@
+---
+- type: replace
+  path: /instance_groups/name=worker/jobs/name=flanneld/properties?/vni
+  value: 4096
+- type: replace
+  path: /instance_groups/name=worker/jobs/name=flanneld/properties?/port
+  value: 4789


### PR DESCRIPTION
I'm not entirely sure I remember why we included this flag in the default Windows opsfile, privileged containers aren't possible on Windows anyway. Either way it is deprecated and is being removed from k8s in v1.15.0-beta.1