### PR TITLE
Support deploying a kubelet on the master node.

### DIFF
--- a/manifests/README.md
+++ b/manifests/README.md
@@ -97,6 +97,7 @@ For deeper documentation to deploy CFCR go [here](https://github.com/cloudfoundr
 | [`ops-files/enable-csi-shared-mounts.yml`](ops-files/enable-csi-shared-mounts.yml) | Enable shared mounts in Docker for CSI volumes | - |
 | [`ops-files/use-hostgw.yml`](ops-files/use-hostgw.yml) | Sets the cluster to use host-gw backend in flannel. Necessary for Windows workers. | - |
 | [`ops-files/set-fs-inotify-limit.yml`](ops-files/set-fs-inotify-limit.yml) | Configure fs.inotify.max_user_watches.| Extra Vars Required:<br>- **fs_inotify_max_user_watches:** Required for configuring the max inotify user watches. |
+| [`ops-files/master-kubelet.yml`](ops-files/master-kubelet.yml) | Installs a kubelet with its dependencies on the master nodes. | EXPERIMENTAL for use with pluggable CNIs.  Must be deployed after `ops-files/change-cidrs.yml`. |
 
 ### Etcd
 

--- a/manifests/ops-files/master-kubelet.yml
+++ b/manifests/ops-files/master-kubelet.yml
@@ -1,0 +1,95 @@
+- type: replace
+  path: /instance_groups/name=master/jobs/-
+  value:
+    name: docker
+    release: docker
+    properties:
+      bridge: cni0
+      default_ulimits:
+      - nofile=1048576
+      env: {}
+      flannel: true
+      ip_masq: false
+      iptables: false
+      live_restore: true
+      log_level: error
+      log_options:
+      - max-size=128m
+      - max-file=2
+      storage_driver: overlay2
+      store_dir: /var/vcap/data
+
+- type: replace
+  path: /instance_groups/name=master/jobs/-
+  value:
+    name: kubelet
+    release: kubo
+    properties:
+      api-token: ((kubelet-password))
+      drain-api-token: ((kubelet-drain-password))
+      master: true
+      k8s-args:
+        cni-bin-dir: /var/vcap/jobs/kubelet/packages/cni/bin
+        container-runtime: docker
+        docker: unix:///var/vcap/sys/run/docker/docker.sock
+        docker-endpoint: unix:///var/vcap/sys/run/docker/docker.sock
+        kubeconfig: /var/vcap/jobs/kubelet/config/kubeconfig
+        network-plugin: cni
+        root-dir: /var/vcap/data/kubelet
+      kubelet-configuration:
+        apiVersion: kubelet.config.k8s.io/v1beta1
+        authentication:
+          anonymous:
+            enabled: false
+          x509:
+            clientCAFile: /var/vcap/jobs/kubelet/config/kubelet-client-ca.pem
+        authorization:
+          mode: Webhook
+        clusterDNS: [((kubedns_service_ip))]
+        clusterDomain: cluster.local
+        failSwapOn: false
+        kind: KubeletConfiguration
+        serializeImagePulls: false
+        tlsCertFile: /var/vcap/jobs/kubelet/config/kubelet.pem
+        tlsPrivateKeyFile: /var/vcap/jobs/kubelet/config/kubelet-key.pem
+      tls:
+        kubelet:
+          ca: ((tls-kubelet.ca))
+          certificate: ((tls-kubelet.certificate))((tls-kubelet.ca))
+          private_key: ((tls-kubelet.private_key))
+        kubelet-client-ca:
+          certificate: ((tls-kubelet-client.ca))
+        kubernetes: ((tls-kubernetes))
+
+- type: replace
+  path: /instance_groups/name=master/jobs/-
+  value:
+    name: kubernetes-dependencies
+    release: kubo
+    properties:
+      nfs: true
+
+- type: replace
+  path: /instance_groups/name=master/jobs/-
+  value:
+    name: kube-proxy
+    release: kubo
+    properties:
+      api-token: ((kube-proxy-password))
+      kube-proxy-configuration:
+        apiVersion: kubeproxy.config.k8s.io/v1alpha1
+        clientConnection:
+          kubeconfig: /var/vcap/jobs/kube-proxy/config/kubeconfig
+        clusterCIDR: ((pod_network_cidr))
+        iptables:
+          masqueradeAll: false
+          masqueradeBit: 14
+          minSyncPeriod: 0s
+          syncPeriod: 30s
+        kind: KubeProxyConfiguration
+        mode: iptables
+        portRange: ""
+      tls:
+        kubernetes: ((tls-kubernetes))
+
+      


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR demonstrates deploying kubelets on the master nodes.   This is the foundation for using Kubernetes itself to install system-level drivers and addons such as pluggable CNI drivers (with some forthcoming examples).

**How can this PR be verified?**
Kubo-ci tests are forthcoming.

```
bosh -d cfcr deploy ./cfcr.yml \
 -o ops-files/add-hostname-to-master-certificate.yml \
 -v api-hostname=<your api hostname> \
 -o ops-files/change-cidrs.yml -o ops-files/master-kubelet.yml \
 -v kubedns_service_ip=10.100.200.2 \
-v service_cluster_cidr=10.100.200.0/24 \
-v pod_network_cidr=10.200.0.0/16 \ 
-v first_ip_of_service_cluster_cidr=10.100.200.1
```

**Is there any change in kubo-release?**
Yes, to enable taints/labels on the master node:  https://github.com/cloudfoundry-incubator/kubo-release/pull/333

**Is there any change in kubo-ci?**
Forthcoming integration/conformance tests with this variant of configuration (and pluggable CNIs)

**Does this affect upgrade, or is there any migration required?**
No, this only adds an extra worker nodes (the masters themselves) to the cluster.

**Which issue(s) this PR fixes:**
N/A 

**Release note**:

```Introduce kubelet jobs on the master node with `ops-files/master-kubelets.yml`.  Requires `ops-files/change-cidrs.yml`.
```
