### PR TITLE
Switch to Microsoft's pause image

### DIFF
--- a/manifests/ops-files/windows/add-worker.yml
+++ b/manifests/ops-files/windows/add-worker.yml
@@ -39,7 +39,7 @@
           keep-terminated-pod-volumes: false
           kubeconfig: C:\var\vcap\jobs\kubelet-windows\config\kubeconfig
           network-plugin: cni
-          pod-infra-container-image: kubeletwin/pause
+          pod-infra-container-image: mcr.microsoft.com/k8s/core/pause:1.2.0
           register-with-taints: windows=2019:NoSchedule
           resolv-conf: ""
           runtime-request-timeout: 1m

--- a/manifests/ops-files/windows/pause-image.yml
+++ b/manifests/ops-files/windows/pause-image.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /instance_groups/name=windows-worker/jobs/name=kubelet-windows/properties/k8s-args/pod-infra-container-image
+  value: ((windows-pause-image))


### PR DESCRIPTION
**What this PR does / why we need it**:
This is the recommended pause image for Windows, and has [wincat](https://github.com/kubernetes-sigs/sig-windows-tools/tree/master/cmd/wincat) in it that will enable port-forwarding starting in k8s 1.15

https://github.com/kubernetes/kubernetes/pull/75479

**How can this PR be verified?**
Deploy it with a 1.15 Windows node, see that you can use `kubectl port-forward` now.

**Is there any change in kubo-release?**
No

**Is there any change in kubo-ci?**
No

**Does this affect upgrade, or is there any migration required?**
No

**Release note**:
```release-note
Port forwarding is now supported for Windows containers
```
