### PR TITLE
Update ruby Gemfile.lock to use bundler 2.0.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,15 +6,15 @@ GEM
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
       rspec-mocks (~> 3.8.0)
-    rspec-core (3.8.0)
+    rspec-core (3.8.2)
       rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.2)
+    rspec-expectations (3.8.4)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
-    rspec-mocks (3.8.0)
+    rspec-mocks (3.8.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
-    rspec-support (3.8.0)
+    rspec-support (3.8.2)
 
 PLATFORMS
   ruby
@@ -23,4 +23,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   2.0.1
+   2.0.2


### PR DESCRIPTION
Signed-off-by: Larry Hamel <lhamel@pivotal.io>

**What this PR does / why we need it**:
The docker image was updated to use bundler 2.0.2. This change aligns our lockfile with that new version.

**How can this PR be verified?**
n/a (pipeline runs)

**Is there any change in kubo-release?**
yes, but only to fix the same gemfile issue
**Is there any change in kubo-ci?**
no
**Does this affect upgrade, or is there any migration required?**
no
**Which issue(s) this PR fixes:**
broken pipeline
**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
N/A
```
