### PR TITLE
Combine windows

### DIFF
--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -443,16 +443,16 @@ releases:
   url: https://storage.googleapis.com/kubo-precompiled-releases/kubo-0.34.0-ubuntu-xenial-315.41-20190621-181712-51217485.tgz
   version: 0.34.0
 - name: cfcr-etcd
-  sha1: e165bbc31f608e803bbe802652a9ea761721f606
-  url: https://storage.googleapis.com/kubo-precompiled-releases/cfcr-etcd-1.11.1-ubuntu-xenial-456.1-20190719-200200-931822779.tgz
+  sha1: c3f8ad93473190dc2c64169dd291556332642a57
+  url: https://storage.googleapis.com/kubo-precompiled-releases/cfcr-etcd-1.11.1-ubuntu-xenial-315.70-20190716-175327-761536081.tgz
   version: 1.11.1
 - name: docker
-  sha1: b9341cc56a8f34b36fddb992147ced977bbd3708
-  url: https://storage.googleapis.com/kubo-precompiled-releases/docker-35.2.1-ubuntu-xenial-456.1-20190719-195754-516061203.tgz
+  sha1: d0ceb29605302fdfd16ef1a89fe2d52a5997a8e9
+  url: https://storage.googleapis.com/kubo-precompiled-releases/docker-35.2.1-ubuntu-xenial-315.70-20190716-174942-710123101.tgz
   version: 35.2.1
 - name: bpm
-  sha1: 2919342547880465b155212f043e7c6d7cfe2164
-  url: https://storage.googleapis.com/kubo-precompiled-releases/bpm-1.0.4-ubuntu-xenial-456.1-20190719-200747-086481328.tgz
+  sha1: 6d4d11a1c5bf47e49085b45937a5824d1e4830a7
+  url: https://storage.googleapis.com/kubo-precompiled-releases/bpm-1.0.4-ubuntu-xenial-315.70-20190716-175908-07910572.tgz
   version: 1.0.4
 stemcells:
 - alias: default

--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -447,8 +447,8 @@ releases:
   url: https://storage.googleapis.com/kubo-precompiled-releases/cfcr-etcd-1.11.1-ubuntu-xenial-315.70-20190716-175327-761536081.tgz
   version: 1.11.1
 - name: docker
-  sha1: ac91457d37b829fc92be5a4d65ba51b9eec0b64a
-  url: https://storage.googleapis.com/kubo-precompiled-releases/docker-35.2.2-ubuntu-xenial-456.1-20190726-015932-607628374.tgz
+  sha1: 5d44642c41e1e5102aef26b03fde149319d1f44c
+  url: https://storage.googleapis.com/kubo-precompiled-releases/docker-35.2.2-ubuntu-xenial-315.70-20190726-051105-252031473.tgz
   version: 35.2.2
 - name: bpm
   sha1: 6d4d11a1c5bf47e49085b45937a5824d1e4830a7

--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -457,7 +457,7 @@ releases:
 stemcells:
 - alias: default
   os: ubuntu-xenial
-  version: "456.1"
+  version: "315.70"
 update:
   canaries: 1
   canary_watch_time: 10000-300000

--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -447,9 +447,9 @@ releases:
   url: https://storage.googleapis.com/kubo-precompiled-releases/cfcr-etcd-1.11.1-ubuntu-xenial-315.70-20190716-175327-761536081.tgz
   version: 1.11.1
 - name: docker
-  sha1: d0ceb29605302fdfd16ef1a89fe2d52a5997a8e9
-  url: https://storage.googleapis.com/kubo-precompiled-releases/docker-35.2.1-ubuntu-xenial-315.70-20190716-174942-710123101.tgz
-  version: 35.2.1
+  sha1: ac91457d37b829fc92be5a4d65ba51b9eec0b64a
+  url: https://storage.googleapis.com/kubo-precompiled-releases/docker-35.2.2-ubuntu-xenial-456.1-20190726-015932-607628374.tgz
+  version: 35.2.2
 - name: bpm
   sha1: 6d4d11a1c5bf47e49085b45937a5824d1e4830a7
   url: https://storage.googleapis.com/kubo-precompiled-releases/bpm-1.0.4-ubuntu-xenial-315.70-20190716-175908-07910572.tgz

--- a/manifests/ops-files/non-precompiled-releases.yml
+++ b/manifests/ops-files/non-precompiled-releases.yml
@@ -10,9 +10,9 @@
     url: https://bosh.io/d/github.com/cloudfoundry-incubator/cfcr-etcd-release?v=1.11.1
     version: 1.11.1
   - name: docker
-    sha1: 8156c3bb04b541fc7a397c1edccc0e35ccebb7c3
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/docker-boshrelease?v=35.2.1
-    version: 35.2.1
+    sha1: e15ffd321abf93c821a53a18d62884f41dccaa62
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/docker-boshrelease?v=35.2.2
+    version: 35.2.2
   - name: bpm
     sha1: 41df19697d6a69d2552bc2c132928157fa91abe0
     url: https://bosh.io/d/github.com/cloudfoundry-incubator/bpm-release?v=1.0.4

--- a/manifests/ops-files/windows/add-worker.yml
+++ b/manifests/ops-files/windows/add-worker.yml
@@ -1,11 +1,11 @@
-- path: /releases/-
+- path: /releases/name=kubo
   type: replace
   value:
     name: kubo
     sha1: 05ead5f098611e25a6fc6e5cfb33825cf1c9b8ae
     url: https://storage.googleapis.com/kubo-precompiled-releases/kubo-windows-0.31.0-windows2019-2019.2-20190325-131732-878123.tgz
     version: 0.35.0
-- path: /releases/-
+- path: /releases/name=docker
   type: replace
   value:
     name: docker

--- a/manifests/ops-files/windows/add-worker.yml
+++ b/manifests/ops-files/windows/add-worker.yml
@@ -1,36 +1,26 @@
+## DO NOT REORDER RELEASES & STEMCELL! KUBO CI RELIES ON THE ARRAY INDEX OF THESE ELEMENTS TO UPDATE THEM 
+- type: replace
+  path: /releases/-
+  value:
+    name: kubo
+    version: "0.35.0"
+    url: https://storage.googleapis.com/kubo-precompiled-releases/kubo-windows-0.31.0-windows2019-2019.2-20190325-131732-878123.tgz
+    sha1: 05ead5f098611e25a6fc6e5cfb33825cf1c9b8ae
+
+- type: replace
+  path: /releases/-
+  value:
+    name: docker
+    version: "35.2.1"
+    url: "https://bosh.io/d/github.com/cloudfoundry-incubator/windows-tools-release?v=32"
+    sha1: 95b6dd94a0b12491afc95e62f393c4d519411239
+
 - type: replace
   path: /stemcells/-
   value:
     alias: windows
     os: windows2019
     version: "2019.2"
-
-- type: replace
-  path: /releases/-
-  value:
-    name: "windows-tools"
-    version: "32"
-    url: "https://bosh.io/d/github.com/cloudfoundry-incubator/windows-tools-release?v=32"
-    sha1: "95b6dd94a0b12491afc95e62f393c4d519411239"
-
-- type: replace
-  path: /releases/-
-  value:
-    name: "kubo-windows"
-    version: "0.31.0"
-    url: "https://storage.googleapis.com/kubo-precompiled-releases/kubo-windows-0.31.0-windows2019-2019.2-20190325-131732-878123.tgz"
-    sha1: "05ead5f098611e25a6fc6e5cfb33825cf1c9b8ae"
-
-- type: replace
-  path: /addons/-
-  value:
-    name: bosh-dns-aliases-windows
-    jobs:
-    - name: kubo-dns-aliases
-      release: kubo-windows
-    include:
-      stemcell:
-      - os: windows2019
 
 - type: replace
   path: /instance_groups/-
@@ -87,9 +77,9 @@
           kubelet-client-ca:
             certificate: ((tls-kubelet-client.ca))
           kubernetes: ((tls-kubernetes))
-      release: kubo-windows
+      release: kubo
     - name: flanneld-windows
-      release: kubo-windows
+      release: kubo
       properties:
         tls:
           etcdctl:
@@ -109,6 +99,17 @@
             kubeconfig: /var/vcap/jobs/kube-proxy-windows/config/kubeconfig
           mode: kernelspace
           portRange: ""
-      release: kubo-windows
+      release: kubo
     - name: docker
-      release: windows-tools
+      release: docker
+
+- type: replace
+  path: /addons/-
+  value:
+    name: bosh-dns-aliases-windows
+    jobs:
+    - name: kubo-dns-aliases
+      release: kubo
+    include:
+      stemcell:
+      - os: windows2019

--- a/manifests/ops-files/windows/add-worker.yml
+++ b/manifests/ops-files/windows/add-worker.yml
@@ -105,6 +105,6 @@
       stemcell:
       - os: windows2019
     jobs:
-    - name: kubo-dns-aliases
+    - name: kubo-dns-aliases-windows
       release: kubo
     name: bosh-dns-aliases-windows

--- a/manifests/ops-files/windows/add-worker.yml
+++ b/manifests/ops-files/windows/add-worker.yml
@@ -91,7 +91,7 @@
         tls:
           kubernetes: ((tls-kubernetes))
       release: kubo
-    - name: docker
+    - name: docker-windows
       release: docker
     name: windows-worker
     networks:

--- a/manifests/ops-files/windows/add-worker.yml
+++ b/manifests/ops-files/windows/add-worker.yml
@@ -17,7 +17,7 @@
   value:
     alias: windows
     os: windows2019
-    version: "2019.2"
+    version: "2019.7"
 - path: /instance_groups/-
   type: replace
   value:

--- a/manifests/ops-files/windows/add-worker.yml
+++ b/manifests/ops-files/windows/add-worker.yml
@@ -1,64 +1,35 @@
-## DO NOT REORDER RELEASES & STEMCELL! KUBO CI RELIES ON THE ARRAY INDEX OF THESE ELEMENTS TO UPDATE THEM 
-- type: replace
-  path: /releases/-
+- path: /releases/-
+  type: replace
   value:
     name: kubo
-    version: "0.35.0"
-    url: https://storage.googleapis.com/kubo-precompiled-releases/kubo-windows-0.31.0-windows2019-2019.2-20190325-131732-878123.tgz
     sha1: 05ead5f098611e25a6fc6e5cfb33825cf1c9b8ae
-
-- type: replace
-  path: /releases/-
+    url: https://storage.googleapis.com/kubo-precompiled-releases/kubo-windows-0.31.0-windows2019-2019.2-20190325-131732-878123.tgz
+    version: 0.35.0
+- path: /releases/-
+  type: replace
   value:
     name: docker
-    version: "35.2.1"
-    url: "https://bosh.io/d/github.com/cloudfoundry-incubator/windows-tools-release?v=32"
-    sha1: 95b6dd94a0b12491afc95e62f393c4d519411239
-
-- type: replace
-  path: /stemcells/-
+    sha1: e15ffd321abf93c821a53a18d62884f41dccaa62
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/docker-boshrelease?v=35.2.2
+    version: 35.2.2
+- path: /stemcells/-
+  type: replace
   value:
     alias: windows
     os: windows2019
     version: "2019.2"
-
-- type: replace
-  path: /instance_groups/-
+- path: /instance_groups/-
+  type: replace
   value:
-    name: windows-worker
-    instances: 3
     azs:
     - z1
     - z2
     - z3
-    networks:
-    - name: default
-    stemcell: windows
-    vm_type: worker
+    instances: 3
     jobs:
     - name: kubelet-windows
       properties:
         api-token: ((kubelet-password))
-        kubelet-configuration:
-          kind: KubeletConfiguration
-          apiVersion: kubelet.config.k8s.io/v1beta1
-          authentication:
-            anonymous:
-              enabled: false
-            x509:
-              clientCAFile: C:\var\vcap\jobs\kubelet-windows\config\kubelet-client-ca.pem
-          authorization:
-            mode: Webhook
-          clusterDNS:
-            - 10.100.200.10
-          clusterDomain: cluster.local
-          failSwapOn: false
-          readOnlyPort: 0
-          serializeImagePulls: false
-          tlsCertFile: C:\var\vcap\jobs\kubelet-windows\config\kubelet.pem
-          tlsPrivateKeyFile: C:\var\vcap\jobs\kubelet-windows\config\kubelet-key.pem
-          cgroupsPerQOS: false
-          enforceNodeAllocatable: []
         drain-api-token: ((kubelet-drain-password))
         k8s-args:
           allow-privileged: true
@@ -72,6 +43,26 @@
           register-with-taints: windows=2019:NoSchedule
           resolv-conf: ""
           runtime-request-timeout: 1m
+        kubelet-configuration:
+          apiVersion: kubelet.config.k8s.io/v1beta1
+          authentication:
+            anonymous:
+              enabled: false
+            x509:
+              clientCAFile: C:\var\vcap\jobs\kubelet-windows\config\kubelet-client-ca.pem
+          authorization:
+            mode: Webhook
+          cgroupsPerQOS: false
+          clusterDNS:
+          - 10.100.200.10
+          clusterDomain: cluster.local
+          enforceNodeAllocatable: []
+          failSwapOn: false
+          kind: KubeletConfiguration
+          readOnlyPort: 0
+          serializeImagePulls: false
+          tlsCertFile: C:\var\vcap\jobs\kubelet-windows\config\kubelet.pem
+          tlsPrivateKeyFile: C:\var\vcap\jobs\kubelet-windows\config\kubelet-key.pem
         tls:
           kubelet: ((tls-kubelet))
           kubelet-client-ca:
@@ -79,37 +70,41 @@
           kubernetes: ((tls-kubernetes))
       release: kubo
     - name: flanneld-windows
-      release: kubo
       properties:
         tls:
           etcdctl:
             ca: ((tls-etcdctl-flanneld.ca))
             certificate: ((tls-etcdctl-flanneld.certificate))
             private_key: ((tls-etcdctl-flanneld.private_key))
+      release: kubo
     - name: kube-proxy-windows
       properties:
         api-token: ((kube-proxy-password))
-        tls:
-          kubernetes: ((tls-kubernetes))
         kube-proxy-configuration:
           apiVersion: kubeproxy.config.k8s.io/v1alpha1
-          kind: KubeProxyConfiguration
-          clusterCIDR: 10.200.0.0/16
           clientConnection:
             kubeconfig: /var/vcap/jobs/kube-proxy-windows/config/kubeconfig
+          clusterCIDR: 10.200.0.0/16
+          kind: KubeProxyConfiguration
           mode: kernelspace
           portRange: ""
+        tls:
+          kubernetes: ((tls-kubernetes))
       release: kubo
     - name: docker
       release: docker
-
-- type: replace
-  path: /addons/-
+    name: windows-worker
+    networks:
+    - name: default
+    stemcell: windows
+    vm_type: worker
+- path: /addons/-
+  type: replace
   value:
-    name: bosh-dns-aliases-windows
-    jobs:
-    - name: kubo-dns-aliases
-      release: kubo
     include:
       stemcell:
       - os: windows2019
+    jobs:
+    - name: kubo-dns-aliases
+      release: kubo
+    name: bosh-dns-aliases-windows


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows us to use the docker-boshrelease that has the docker-windows job. It forces the user to use the uncompiled docker-boshrelease when a user adds windows workers. This change does the same thing for the recombined kubo/kubo-windows release. 

**How can this PR be verified?**
Run it through the normal pipelines
**Is there any change in kubo-release?**
Yes. There is a change to bring the Windows jobs back into that release.
**Is there any change in kubo-ci?**
Yes. Some scripts need to be updated to support compiling the windows releases
**Does this affect upgrade, or is there any migration required?**
No
**Which issue(s) this PR fixes:**

**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
This release recombines the kubo-release and kubo-release-windows. It no longer depends on kubo-release-windows. When using Windows workers the precompiled releases for docker-boshrelease and kubo-release will be replaced with the uncompiled releases.
```
