### PR TITLE
ops file for docker standard networking

### DIFF
--- a/manifests/README.md
+++ b/manifests/README.md
@@ -134,3 +134,8 @@ For deeper documentation to deploy CFCR go [here](https://github.com/cloudfoundr
 | Name | Purpose | Notes |
 |:---  |:---     |:---   |
 | [`ops-files/kubo-local-release.yml`](ops-files/kubo-local-release.yml) | Deploy a local kubo release located in `../kubo-release` | -  |
+
+### Docker
+| Name | Purpose | Notes |
+|:---  |:---     |:---   |
+| [`ops-files/docker-sans-flannel.yml`](ops-files/docker-sans-flannel.yml) | Configure Docker Daemeon with standard networking settings (docker0 bridge), and let Kubelet/CNI manage cni0 bridge | This allows Bosh to recover/recreate worker nodes when flannel fails to renew subnet lease and a new one is assigned creating a sync problem between flannel.1 and cni0 |

--- a/manifests/ops-files/docker-sans-flannel.yml
+++ b/manifests/ops-files/docker-sans-flannel.yml
@@ -1,0 +1,3 @@
+- type: replace
+  path: /instance_groups/name=worker/jobs/name=docker/properties/flannel
+  value: false


### PR DESCRIPTION
**What this PR does / why we need it**:
Configure docker daemon with standard networking settings (docker0 bridge), letting Kubelet/CNI manage cni0 bridge.
With this change the cni0 configuration is no longer kept in the docker store (when persistent disks are attached to the worker nodes) so we solve the problem of stale data sticking around when flannel leases expire, and it should also make it easier to keep cni0 in sync with flannel.1
Idea credit: @alekssaul 

**How can this PR be verified?**
Applying the Ops-file including in the changes and 

**Is there any change in kubo-release?**
Not at this time

**Is there any change in kubo-ci?**
Not required, but recommended when approved

**Does this affect upgrade, or is there any migration required?**
No impact.

**Which issue(s) this PR fixes:**
When flannel lease expire and flannel.1 and cni0 go out of sync, rebooting/recreating the worker nodes doesn't solve the problem but make it worse, because the old/stale subnet info is kept in the docker store (`/var/vcap/store/docker/docker/network/files/local-kv.d`) and that is still used to configure cni0 even after recreating the worker node. With this fix, docker no longer owns cni0 so we can rely on rebootings/bosh-recreate to recover worker nodes out of sync

**Release note**:
NONE
