### PR TITLE
Allow customizing Windows CIDRs

### DIFF
--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -42,6 +42,8 @@ instance_groups:
   - name: bpm
     release: bpm
   - name: flanneld
+    provides:
+      flanneld: {as: worker-flanneld}
     properties:
       tls:
         etcdctl:

--- a/manifests/ops-files/windows/add-worker.yml
+++ b/manifests/ops-files/windows/add-worker.yml
@@ -66,6 +66,8 @@
             certificate: ((tls-etcdctl-flanneld.certificate))
             private_key: ((tls-etcdctl-flanneld.private_key))
       release: kubo-windows
+      consumes:
+        flanneld: {from: worker-flanneld}
     - name: kube-proxy-windows
       properties:
         api-token: ((kube-proxy-password))

--- a/manifests/ops-files/windows/change-cidrs.yml
+++ b/manifests/ops-files/windows/change-cidrs.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /instance_groups/name=windows-worker/jobs/name=flanneld-windows/properties?/kubedns-service-ip
+  value: ((kubedns_service_ip))


### PR DESCRIPTION
Pull the pod CIDR from flanneld on Linux, expose the kubedns service IP with an opsfile. Not sure whether the Windows jobs will continue to come from kubo-release-windows or kubo-release now but ignoring that problem for now :).

https://github.com/cloudfoundry-incubator/kubo-release-windows/pull/18
https://github.com/cloudfoundry-incubator/kubo-release/pull/349