### PR TITLE
Move docker-windows to inside kubo

### DIFF
--- a/manifests/ops-files/windows/add-worker.yml
+++ b/manifests/ops-files/windows/add-worker.yml
@@ -92,7 +92,7 @@
           kubernetes: ((tls-kubernetes))
       release: kubo
     - name: docker-windows
-      release: docker
+      release: kubo
     name: windows-worker
     networks:
     - name: default


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds docker-windows job. Needed to avoid depending on https://github.com/cloudfoundry/windows-tools-release/ and since @srm09 said it was causing problems to have it in https://github.com/cloudfoundry-incubator/docker-boshrelease 

**Is there any change in kubo-release?**
https://github.com/cloudfoundry-incubator/kubo-release/pull/357

**Is there any change in kubo-ci?**
Yes, will link once I create that PR

**Does this affect upgrade, or is there any migration required?**
No
