### PR TITLE
Adds empty tag k8s-args to kube-scheduler

### DIFF
--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -290,6 +290,7 @@ instance_groups:
           kubeconfig: /var/vcap/jobs/kube-scheduler/config/kubeconfig
         disablePreemption: false
         kind: KubeSchedulerConfiguration
+      k8s-args:
       tls:
         kubernetes: ((tls-kubernetes))
     release: kubo


### PR DESCRIPTION
Authored-by: Gene Hynson <ghynson@pivotal.io>
Authored-by: Gavin Morgan <gmorgan@pivotal.io>

**What this PR does / why we need it**:
This PR introduces the empty key for `k8s-args` for the `kube-scheduler` job to prevent unwanted null pointers at `create cluster` time.
<!--
Why is this PR important? What is the user impact?
-->
The PR doesn't affect functionality. It just makes the manifest more consistent. Every kube job should have `k8s-args` key.

**How can this PR be verified?**
See that a bosh deployment with this manifest is successful and that kube-scheduler has an empty map for k8s-args.

**Is there any change in kubo-release?**
no

**Is there any change in kubo-ci?**
no

**Does this affect upgrade, or is there any migration required?**
no

**Which issue(s) this PR fixes:**
It fixes a potential null pointer exception if consuming projects assume that `k8s-args` yaml key will exist for all kube jobs.

**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
