### PR TITLE
Persist node taint label

### DIFF
--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -450,12 +450,12 @@ releases:
   url: https://storage.googleapis.com/kubo-precompiled-releases/kubo-0.42.0-ubuntu-xenial-621.59-20200318-043947-801128414.tgz
   version: 0.42.0
 - name: cfcr-etcd
-  sha1: 84553ee24a82cea62e345c9a7f6e8a943bd76b3c
+  sha1: 2128707d39631c75c09a098508ed76d70aa466d9
   stemcell:
     os: ubuntu-xenial
     version: 621.61
-  url: https://storage.googleapis.com/kubo-precompiled-releases/cfcr-etcd-1.12.0-ubuntu-xenial-621.61-20200324-183827-559716853.tgz
-  version: 1.12.0
+  url: https://storage.googleapis.com/kubo-precompiled-releases/cfcr-etcd-1.12.1-ubuntu-xenial-621.61-20200402-165403-46293314.tgz
+  version: 1.12.1
 - name: docker
   sha1: 8c6cbc23773ba9fa05c675baeb8e53fc0c7a0432
   stemcell:

--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -450,25 +450,25 @@ releases:
   url: https://storage.googleapis.com/kubo-precompiled-releases/kubo-0.42.0-ubuntu-xenial-621.59-20200318-043947-801128414.tgz
   version: 0.42.0
 - name: cfcr-etcd
-  sha1: 2128707d39631c75c09a098508ed76d70aa466d9
+  sha1: 521f84d797bcf77e8c54a5ad08527b75e429dd38
   stemcell:
     os: ubuntu-xenial
-    version: 621.61
-  url: https://storage.googleapis.com/kubo-precompiled-releases/cfcr-etcd-1.12.1-ubuntu-xenial-621.61-20200402-165403-46293314.tgz
+    version: 621.64
+  url: https://storage.googleapis.com/kubo-precompiled-releases/cfcr-etcd-1.12.1-ubuntu-xenial-621.64-20200406-195611-40255587.tgz
   version: 1.12.1
 - name: docker
-  sha1: 8c6cbc23773ba9fa05c675baeb8e53fc0c7a0432
+  sha1: 45f92c0689eae3d51dadad32c826f439a5c06e77
   stemcell:
     os: ubuntu-xenial
-    version: 621.61
-  url: https://storage.googleapis.com/kubo-precompiled-releases/docker-35.3.4-ubuntu-xenial-621.61-20200324-183500-341581949.tgz
+    version: 621.64
+  url: https://storage.googleapis.com/kubo-precompiled-releases/docker-35.3.4-ubuntu-xenial-621.64-20200406-195238-322598225.tgz
   version: 35.3.4
 - name: bpm
-  sha1: 5575b1af4eff8b305217b1e7d052796f7b99e481
+  sha1: 65064d3cde203d2d52370bb23624369c67c870cc
   stemcell:
     os: ubuntu-xenial
-    version: 621.61
-  url: https://storage.googleapis.com/kubo-precompiled-releases/bpm-1.1.8-ubuntu-xenial-621.61-20200324-184320-814930271.tgz
+    version: 621.64
+  url: https://storage.googleapis.com/kubo-precompiled-releases/bpm-1.1.8-ubuntu-xenial-621.64-20200406-200101-733865637.tgz
   version: 1.1.8
 stemcells:
 - alias: default

--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -473,7 +473,7 @@ releases:
 stemcells:
 - alias: default
   os: ubuntu-xenial
-  version: "621.71"
+  version: "621.74"
 update:
   canaries: 1
   canary_watch_time: 10000-300000

--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -473,7 +473,7 @@ releases:
 stemcells:
 - alias: default
   os: ubuntu-xenial
-  version: "621.69"
+  version: "621.71"
 update:
   canaries: 1
   canary_watch_time: 10000-300000

--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -464,12 +464,12 @@ releases:
   url: https://storage.googleapis.com/kubo-precompiled-releases/docker-35.3.4-ubuntu-xenial-621.59-20200318-020406-158951195.tgz
   version: 35.3.4
 - name: bpm
-  sha1: ca2493e8ed0b1bd68b680873754b4a4859ab6ba8
+  sha1: cc3d4459a0895e505293fa07fef4fb8ed208daec
   stemcell:
     os: ubuntu-xenial
     version: 621.59
-  url: https://storage.googleapis.com/kubo-precompiled-releases/bpm-1.0.4-ubuntu-xenial-621.59-20200318-021346-51657506.tgz
-  version: 1.0.4
+  url: https://storage.googleapis.com/kubo-precompiled-releases/bpm-1.1.8-ubuntu-xenial-621.59-20200323-004217-51765147.tgz
+  version: 1.1.8
 stemcells:
 - alias: default
   os: ubuntu-xenial

--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -450,25 +450,25 @@ releases:
   url: https://storage.googleapis.com/kubo-precompiled-releases/kubo-0.42.0-ubuntu-xenial-621.59-20200318-043947-801128414.tgz
   version: 0.42.0
 - name: cfcr-etcd
-  sha1: 2b6d76701c39d687fa16fa7693c3b9f54dc940c5
+  sha1: 84553ee24a82cea62e345c9a7f6e8a943bd76b3c
   stemcell:
     os: ubuntu-xenial
-    version: 621.59
-  url: https://storage.googleapis.com/kubo-precompiled-releases/cfcr-etcd-1.12.0-ubuntu-xenial-621.59-20200318-020736-99569121.tgz
+    version: 621.61
+  url: https://storage.googleapis.com/kubo-precompiled-releases/cfcr-etcd-1.12.0-ubuntu-xenial-621.61-20200324-183827-559716853.tgz
   version: 1.12.0
 - name: docker
-  sha1: a1946715d4f6f86a648613911fa87091b8737a8c
+  sha1: 8c6cbc23773ba9fa05c675baeb8e53fc0c7a0432
   stemcell:
     os: ubuntu-xenial
-    version: 621.59
-  url: https://storage.googleapis.com/kubo-precompiled-releases/docker-35.3.4-ubuntu-xenial-621.59-20200318-020406-158951195.tgz
+    version: 621.61
+  url: https://storage.googleapis.com/kubo-precompiled-releases/docker-35.3.4-ubuntu-xenial-621.61-20200324-183500-341581949.tgz
   version: 35.3.4
 - name: bpm
-  sha1: cc3d4459a0895e505293fa07fef4fb8ed208daec
+  sha1: 5575b1af4eff8b305217b1e7d052796f7b99e481
   stemcell:
     os: ubuntu-xenial
-    version: 621.59
-  url: https://storage.googleapis.com/kubo-precompiled-releases/bpm-1.1.8-ubuntu-xenial-621.59-20200323-004217-51765147.tgz
+    version: 621.61
+  url: https://storage.googleapis.com/kubo-precompiled-releases/bpm-1.1.8-ubuntu-xenial-621.61-20200324-184320-814930271.tgz
   version: 1.1.8
 stemcells:
 - alias: default

--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -450,25 +450,25 @@ releases:
   url: https://storage.googleapis.com/kubo-precompiled-releases/kubo-0.42.0-ubuntu-xenial-621.59-20200318-043947-801128414.tgz
   version: 0.42.0
 - name: cfcr-etcd
-  sha1: 2f4523aa7477c7abdad1f6ed77cd4784065eec5f
+  sha1: cd800e0813857fabcbec4a3109b31671175dc3cc
   stemcell:
     os: ubuntu-xenial
-    version: 621.69
-  url: https://storage.googleapis.com/kubo-precompiled-releases/cfcr-etcd-1.12.1-ubuntu-xenial-621.69-20200417-155430-526064642.tgz
+    version: 621.71
+  url: https://storage.googleapis.com/kubo-precompiled-releases/cfcr-etcd-1.12.1-ubuntu-xenial-621.71-20200422-220101-35856781.tgz
   version: 1.12.1
 - name: docker
-  sha1: c194edfca1c8f0903d28d30625fcafefd2803cc9
+  sha1: d5ac1dd5a551678a0542166cb27ab5b91491958e
   stemcell:
     os: ubuntu-xenial
-    version: 621.69
-  url: https://storage.googleapis.com/kubo-precompiled-releases/docker-35.3.4-ubuntu-xenial-621.69-20200417-155104-747231297.tgz
+    version: 621.71
+  url: https://storage.googleapis.com/kubo-precompiled-releases/docker-35.3.4-ubuntu-xenial-621.71-20200422-215730-408660484.tgz
   version: 35.3.4
 - name: bpm
-  sha1: 713e114a27e551042668607f279f8ba4897cdade
+  sha1: 9cc75ecfdc721c5a5a253fd9359b57ee35f17971
   stemcell:
     os: ubuntu-xenial
-    version: 621.69
-  url: https://storage.googleapis.com/kubo-precompiled-releases/bpm-1.1.8-ubuntu-xenial-621.69-20200417-155940-180299288.tgz
+    version: 621.71
+  url: https://storage.googleapis.com/kubo-precompiled-releases/bpm-1.1.8-ubuntu-xenial-621.71-20200422-220607-935179416.tgz
   version: 1.1.8
 stemcells:
 - alias: default

--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -450,25 +450,25 @@ releases:
   url: https://storage.googleapis.com/kubo-precompiled-releases/kubo-0.42.0-ubuntu-xenial-621.59-20200318-043947-801128414.tgz
   version: 0.42.0
 - name: cfcr-etcd
-  sha1: cd800e0813857fabcbec4a3109b31671175dc3cc
+  sha1: a6da7e1f065e90197d099ac07595cec471c75d55
   stemcell:
     os: ubuntu-xenial
-    version: 621.71
-  url: https://storage.googleapis.com/kubo-precompiled-releases/cfcr-etcd-1.12.1-ubuntu-xenial-621.71-20200422-220101-35856781.tgz
+    version: 621.74
+  url: https://storage.googleapis.com/kubo-precompiled-releases/cfcr-etcd-1.12.1-ubuntu-xenial-621.74-20200505-205530-879033421.tgz
   version: 1.12.1
 - name: docker
-  sha1: d5ac1dd5a551678a0542166cb27ab5b91491958e
+  sha1: 2eefbed1f505ef802285427f6e74a95135b03955
   stemcell:
     os: ubuntu-xenial
-    version: 621.71
-  url: https://storage.googleapis.com/kubo-precompiled-releases/docker-35.3.4-ubuntu-xenial-621.71-20200422-215730-408660484.tgz
+    version: 621.74
+  url: https://storage.googleapis.com/kubo-precompiled-releases/docker-35.3.4-ubuntu-xenial-621.74-20200505-205157-543493778.tgz
   version: 35.3.4
 - name: bpm
-  sha1: 9cc75ecfdc721c5a5a253fd9359b57ee35f17971
+  sha1: 725c7c615d28f772ddd4f04b70822d2f8bab9597
   stemcell:
     os: ubuntu-xenial
-    version: 621.71
-  url: https://storage.googleapis.com/kubo-precompiled-releases/bpm-1.1.8-ubuntu-xenial-621.71-20200422-220607-935179416.tgz
+    version: 621.74
+  url: https://storage.googleapis.com/kubo-precompiled-releases/bpm-1.1.8-ubuntu-xenial-621.74-20200505-210038-093981234.tgz
   version: 1.1.8
 stemcells:
 - alias: default

--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -473,7 +473,7 @@ releases:
 stemcells:
 - alias: default
   os: ubuntu-xenial
-  version: "621.61"
+  version: "621.64"
 update:
   canaries: 1
   canary_watch_time: 10000-300000

--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -450,25 +450,25 @@ releases:
   url: https://storage.googleapis.com/kubo-precompiled-releases/kubo-0.42.0-ubuntu-xenial-621.59-20200318-043947-801128414.tgz
   version: 0.42.0
 - name: cfcr-etcd
-  sha1: dee2b9fd09fecb76cb47bf07c2240ef2b9e70185
+  sha1: 2b6d76701c39d687fa16fa7693c3b9f54dc940c5
   stemcell:
     os: ubuntu-xenial
     version: 621.59
-  url: https://storage.googleapis.com/kubo-precompiled-releases/cfcr-etcd-1.12.0-ubuntu-xenial-621.59-20200311-153104-347808796.tgz
+  url: https://storage.googleapis.com/kubo-precompiled-releases/cfcr-etcd-1.12.0-ubuntu-xenial-621.59-20200318-020736-99569121.tgz
   version: 1.12.0
 - name: docker
-  sha1: 4a24b1708a69910ee45cd6329c47586faebf8899
+  sha1: a1946715d4f6f86a648613911fa87091b8737a8c
   stemcell:
     os: ubuntu-xenial
     version: 621.59
-  url: https://storage.googleapis.com/kubo-precompiled-releases/docker-35.3.4-ubuntu-xenial-621.59-20200311-151455-402852852.tgz
+  url: https://storage.googleapis.com/kubo-precompiled-releases/docker-35.3.4-ubuntu-xenial-621.59-20200318-020406-158951195.tgz
   version: 35.3.4
 - name: bpm
-  sha1: c73f99d0dfd937368b325b99374fc868012e558f
+  sha1: ca2493e8ed0b1bd68b680873754b4a4859ab6ba8
   stemcell:
     os: ubuntu-xenial
     version: 621.59
-  url: https://storage.googleapis.com/kubo-precompiled-releases/bpm-1.0.4-ubuntu-xenial-621.59-20200311-151626-774477706.tgz
+  url: https://storage.googleapis.com/kubo-precompiled-releases/bpm-1.0.4-ubuntu-xenial-621.59-20200318-021346-51657506.tgz
   version: 1.0.4
 stemcells:
 - alias: default

--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -473,7 +473,7 @@ releases:
 stemcells:
 - alias: default
   os: ubuntu-xenial
-  version: "621.59"
+  version: "621.61"
 update:
   canaries: 1
   canary_watch_time: 10000-300000

--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -450,25 +450,25 @@ releases:
   url: https://storage.googleapis.com/kubo-precompiled-releases/kubo-0.42.0-ubuntu-xenial-621.59-20200318-043947-801128414.tgz
   version: 0.42.0
 - name: cfcr-etcd
-  sha1: 521f84d797bcf77e8c54a5ad08527b75e429dd38
+  sha1: 2f4523aa7477c7abdad1f6ed77cd4784065eec5f
   stemcell:
     os: ubuntu-xenial
-    version: 621.64
-  url: https://storage.googleapis.com/kubo-precompiled-releases/cfcr-etcd-1.12.1-ubuntu-xenial-621.64-20200406-195611-40255587.tgz
+    version: 621.69
+  url: https://storage.googleapis.com/kubo-precompiled-releases/cfcr-etcd-1.12.1-ubuntu-xenial-621.69-20200417-155430-526064642.tgz
   version: 1.12.1
 - name: docker
-  sha1: 45f92c0689eae3d51dadad32c826f439a5c06e77
+  sha1: c194edfca1c8f0903d28d30625fcafefd2803cc9
   stemcell:
     os: ubuntu-xenial
-    version: 621.64
-  url: https://storage.googleapis.com/kubo-precompiled-releases/docker-35.3.4-ubuntu-xenial-621.64-20200406-195238-322598225.tgz
+    version: 621.69
+  url: https://storage.googleapis.com/kubo-precompiled-releases/docker-35.3.4-ubuntu-xenial-621.69-20200417-155104-747231297.tgz
   version: 35.3.4
 - name: bpm
-  sha1: 65064d3cde203d2d52370bb23624369c67c870cc
+  sha1: 713e114a27e551042668607f279f8ba4897cdade
   stemcell:
     os: ubuntu-xenial
-    version: 621.64
-  url: https://storage.googleapis.com/kubo-precompiled-releases/bpm-1.1.8-ubuntu-xenial-621.64-20200406-200101-733865637.tgz
+    version: 621.69
+  url: https://storage.googleapis.com/kubo-precompiled-releases/bpm-1.1.8-ubuntu-xenial-621.69-20200417-155940-180299288.tgz
   version: 1.1.8
 stemcells:
 - alias: default

--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -252,6 +252,7 @@ instance_groups:
       kube-proxy-password: ((kube-proxy-password))
       kube-scheduler-password: ((kube-scheduler-password))
       kubelet-drain-password: ((kubelet-drain-password))
+      kubelet-pre-stop-password: ((kubelet-pre-stop-password))
       kubelet-password: ((kubelet-password))
       service-account-public-key: ((service-account-key.public_key))
       tls:
@@ -382,6 +383,7 @@ instance_groups:
     properties:
       api-token: ((kubelet-password))
       drain-api-token: ((kubelet-drain-password))
+      pre-stop-api-token: ((kubelet-pre-stop-password))
       k8s-args:
         cni-bin-dir: /var/vcap/jobs/kubelet/packages/cni/bin
         container-runtime: docker
@@ -485,6 +487,8 @@ variables:
 - name: kubelet-password
   type: password
 - name: kubelet-drain-password
+  type: password
+- name: kubelet-pre-stop-password
   type: password
 - name: kube-proxy-password
   type: password

--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -473,7 +473,7 @@ releases:
 stemcells:
 - alias: default
   os: ubuntu-xenial
-  version: "621.64"
+  version: "621.69"
 update:
   canaries: 1
   canary_watch_time: 10000-300000

--- a/manifests/ops-files/non-precompiled-releases.yml
+++ b/manifests/ops-files/non-precompiled-releases.yml
@@ -6,9 +6,9 @@
     url: https://github.com/cloudfoundry-incubator/kubo-release/releases/download/v0.42.0/kubo-release-0.42.0.tgz
     version: 0.42.0
   - name: cfcr-etcd
-    sha1: 8931ee4972bee22b4c5ebf7e7019521a0b5b728d
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/cfcr-etcd-release?v=1.12.0
-    version: 1.12.0
+    sha1: 40279e2c16e6a79ddf0928992974a729d7c9d615
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/cfcr-etcd-release?v=1.12.1
+    version: 1.12.1
   - name: docker
     sha1: 8dcacf558067ed5302e30e4c8de928ee7917695e
     url: https://bosh.io/d/github.com/cloudfoundry-incubator/docker-boshrelease?v=35.3.4

--- a/manifests/ops-files/non-precompiled-releases.yml
+++ b/manifests/ops-files/non-precompiled-releases.yml
@@ -14,6 +14,6 @@
     url: https://bosh.io/d/github.com/cloudfoundry-incubator/docker-boshrelease?v=35.3.4
     version: 35.3.4
   - name: bpm
-    sha1: 41df19697d6a69d2552bc2c132928157fa91abe0
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/bpm-release?v=1.0.4
-    version: 1.0.4
+    sha1: c956394fce7e74f741e4ae8c256b480904ad5942
+    url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.8
+    version: 1.1.8

--- a/manifests/ops-files/windows/add-worker.yml
+++ b/manifests/ops-files/windows/add-worker.yml
@@ -11,7 +11,7 @@
   value:
     alias: windows
     os: windows2019
-    version: "2019.7"
+    version: "2019.17"
 - path: /instance_groups/-
   type: replace
   value:


### PR DESCRIPTION
**What this PR does / why we need it**:
PKS users, Alana or Cody, want to assign labels or taint to nodes. And those labels and taints are expected to be persistent regardless of PKS upgrade, bosh recreate VM or other incidents - unless the operator removed it intentionally.

**How can this PR be verified?**
https://pks.ci.cf-app.com/teams/dev/pipelines/pks-api-persist_node_taint_label

**Is there any change in kubo-release?**
yes
**Is there any change in kubo-ci?**
no
**Does this affect upgrade, or is there any migration required?**
no migration
**Which issue(s) this PR fixes:**
https://docs.google.com/document/d/1mbhPLfMw0sbMcNScQm5aeJhQTwZf76V0pZQkpMbXmy8/edit?ts=5eb51956&pli=1#
https://www.pivotaltracker.com/story/show/172862983

