### PR TITLE
Add kubelet-pre-stop-password to cfcr.yml

### DIFF
--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -252,6 +252,7 @@ instance_groups:
       kube-proxy-password: ((kube-proxy-password))
       kube-scheduler-password: ((kube-scheduler-password))
       kubelet-drain-password: ((kubelet-drain-password))
+      kubelet-pre-stop-password: ((kubelet-pre-stop-password))
       kubelet-password: ((kubelet-password))
       service-account-public-key: ((service-account-key.public_key))
       tls:
@@ -382,6 +383,7 @@ instance_groups:
     properties:
       api-token: ((kubelet-password))
       drain-api-token: ((kubelet-drain-password))
+      pre-stop-api-token: ((kubelet-pre-stop-password))
       k8s-args:
         cni-bin-dir: /var/vcap/jobs/kubelet/packages/cni/bin
         container-runtime: docker
@@ -485,6 +487,8 @@ variables:
 - name: kubelet-password
   type: password
 - name: kubelet-drain-password
+  type: password
+- name: kubelet-pre-stop-password
   type: password
 - name: kube-proxy-password
   type: password


### PR DESCRIPTION
**What this PR does / why we need it**:
PKS users, Alana or Cody, want to assign labels or taint to nodes. And those labels and taints are expected to be persistent regardless of PKS upgrade, bosh recreate VM or other incidents - unless the operator removed it intentionally.

**How can this PR be verified?**
https://pks.ci.cf-app.com/teams/dev/pipelines/pks-api-persist_node_taint_label

**Is there any change in kubo-release?**
yes
**Is there any change in kubo-ci?**
no
**Does this affect upgrade, or is there any migration required?**
no migration
**Which issue(s) this PR fixes:**
https://docs.google.com/document/d/1mbhPLfMw0sbMcNScQm5aeJhQTwZf76V0pZQkpMbXmy8/edit?ts=5eb51956&pli=1#
https://www.pivotaltracker.com/story/show/172862983

